### PR TITLE
Added an option to ignore General Macros with import/export

### DIFF
--- a/Myslot.lua
+++ b/Myslot.lua
@@ -585,7 +585,12 @@ function MySlot:RecoverData(msg, opt)
                         elseif slotType == MYSLOT_ITEM then
                             PickupItem(index)
                         elseif slotType == MYSLOT_MACRO then
-                            local macroid = self:FindOrCreateMacro(macro[index])
+                            local macroid
+                            if opt.ignoreGeneralMacro and index <= MAX_ACCOUNT_MACROS then
+                                macroid = index
+                            else
+                                macroid = self:FindOrCreateMacro(macro[index])
+                            end
 
                             if curType ~= MYSLOT_MACRO or curIndex ~= index then
                                 PickupMacro(macroid)

--- a/Myslot.lua
+++ b/Myslot.lua
@@ -516,7 +516,7 @@ function MySlot:RecoverData(msg, opt)
     local macro = {}
     if not opt.ignoreMacro then
         if opt.clearMacro then
-            MySlot:Clear("MACRO")
+            MySlot:Clear("MACRO", opt)
         end
 
         for _, m in pairs(msg.macro or {}) do
@@ -542,7 +542,7 @@ function MySlot:RecoverData(msg, opt)
 
     if (not opt.ignoreAction) then
         if opt.clearAction then
-            MySlot:Clear("ACTION")
+            MySlot:Clear("ACTION", opt)
         end
 
         local slotBucket = {}
@@ -636,7 +636,7 @@ function MySlot:RecoverData(msg, opt)
 
     if not opt.ignoreBinding then
         if opt.clearBinding then
-            MySlot:Clear("BINDING")
+            MySlot:Clear("BINDING", opt)
         end
 
         for _, b in pairs(msg.bind or {}) do
@@ -669,7 +669,7 @@ function MySlot:RecoverData(msg, opt)
     MySlot:Print(L["All slots were restored"])
 end
 
-function MySlot:Clear(what)
+function MySlot:Clear(what, opt)
     if what == "ACTION" then
         for i = 1, MYSLOT_MAX_ACTIONBAR do
             PickupAction(i)
@@ -677,7 +677,7 @@ function MySlot:Clear(what)
         end
     elseif what == "MACRO" then
         local initIndex = 1
-        if opt.ignoreGeneralMacro then
+        if opt and opt.ignoreGeneralMacro then
             initIndex = MAX_ACCOUNT_MACROS + 1
         end
 

--- a/Myslot.lua
+++ b/Myslot.lua
@@ -261,7 +261,12 @@ function MySlot:Export(opt)
     msg.macro = {}
 
     if not opt.ignoreMacro then
-        for i = 1, MAX_ACCOUNT_MACROS + MAX_CHARACTER_MACROS do
+        local initIndex = 1
+        if opt.ignoreGeneralMacro then
+            initIndex = MAX_ACCOUNT_MACROS + 1
+        end
+
+        for i = initIndex, MAX_ACCOUNT_MACROS + MAX_CHARACTER_MACROS do
             local m = self:GetMacroInfo(i)
             if m then
                 msg.macro[#msg.macro + 1] = m
@@ -515,20 +520,22 @@ function MySlot:RecoverData(msg, opt)
         end
 
         for _, m in pairs(msg.macro or {}) do
-            local macroId = m.id
-            local icon = m.icon
+            if not opt.ignoreGeneralMacro or m.id > MAX_ACCOUNT_MACROS then
+                local macroId = m.id
+                local icon = m.icon
 
-            local name = m.name
-            local body = m.body
+                local name = m.name
+                local body = m.body
 
-            macro[macroId] = {
-                ["oldid"] = macroId,
-                ["name"] = name,
-                ["icon"] = icon,
-                ["body"] = body,
-            }
+                macro[macroId] = {
+                    ["oldid"] = macroId,
+                    ["name"] = name,
+                    ["icon"] = icon,
+                    ["body"] = body,
+                }
 
-            self:FindOrCreateMacro(macro[macroId])
+                self:FindOrCreateMacro(macro[macroId])
+            end
         end
     end
     -- }}} Macro
@@ -669,7 +676,12 @@ function MySlot:Clear(what)
             ClearCursor()
         end
     elseif what == "MACRO" then
-        for i = MAX_ACCOUNT_MACROS + MAX_CHARACTER_MACROS, 1, -1 do
+        local initIndex = 1
+        if opt.ignoreGeneralMacro then
+            initIndex = MAX_ACCOUNT_MACROS + 1
+        end
+
+        for i = MAX_ACCOUNT_MACROS + MAX_CHARACTER_MACROS, initIndex, -1 do
             DeleteMacro(i)
         end
     elseif what == "BINDING" then

--- a/gui.lua
+++ b/gui.lua
@@ -86,6 +86,7 @@ do
     local ignoreActionCheckbox
     local ignoreBindingCheckbox
     local ignoreMacroCheckbox
+    local ignoreGeneralMacroCheckbox
     local clearActionCheckbox
     local clearBindingCheckbox
     local clearMacroCheckbox
@@ -136,6 +137,16 @@ do
         local b = CreateFrame("CheckButton", nil, f, "UICheckButtonTemplate")
         b.text = b:CreateFontString(nil, "OVERLAY", "GameFontNormal")
         b.text:SetPoint("LEFT", b, "RIGHT", 0, 1)
+        b:SetPoint("BOTTOMLEFT", 38, 20)
+        b.text:SetText(L["Ignore General Macros"])
+        b:SetScript("OnClick", updateButton)
+        ignoreGeneralMacroCheckbox = b
+    end
+
+    do
+        local b = CreateFrame("CheckButton", nil, f, "UICheckButtonTemplate")
+        b.text = b:CreateFontString(nil, "OVERLAY", "GameFontNormal")
+        b.text:SetPoint("LEFT", b, "RIGHT", 0, 1)
         b:SetPoint("BOTTOMLEFT", 340, 95)
         b.text:SetText(L["Clear Action before applying"])
         clearActionCheckbox = b
@@ -166,6 +177,7 @@ do
                 ignoreAction = ignoreActionCheckbox:GetChecked(),
                 ignoreBinding = ignoreBindingCheckbox:GetChecked(),
                 ignoreMacro = ignoreMacroCheckbox:GetChecked(),
+                ignoreGeneralMacro = ignoreGeneralMacroCheckbox:GetChecked(),
                 clearAction = clearActionCheckbox:GetChecked(),
                 clearBinding = clearBindingCheckbox:GetChecked(),
                 clearMacro = clearMacroCheckbox:GetChecked(),
@@ -521,6 +533,7 @@ SlashCmdList["MYSLOT"] = function(msg, editbox)
                 ignoreAction = false,
                 ignoreBinding = false,
                 ignoreMacro = false,
+                ignoreGeneralMacro = false,
                 clearAction = false,
                 clearBinding = false,
                 clearMacro = false,

--- a/gui.lua
+++ b/gui.lua
@@ -7,7 +7,7 @@ local MAX_PROFILES_COUNT = 50
 
 local f = CreateFrame("Frame", nil, UIParent, BackdropTemplateMixin and "BackdropTemplate" or nil)
 f:SetWidth(650)
-f:SetHeight(600)
+f:SetHeight(625)
 f:SetBackdrop({
     bgFile = "Interface\\DialogFrame\\UI-DialogBox-Background",
     edgeFile = "Interface\\DialogFrame\\UI-DialogBox-Border",
@@ -107,7 +107,7 @@ do
         local b = CreateFrame("CheckButton", nil, f, "UICheckButtonTemplate")
         b.text = b:CreateFontString(nil, "OVERLAY", "GameFontNormal")
         b.text:SetPoint("LEFT", b, "RIGHT", 0, 1)
-        b:SetPoint("BOTTOMLEFT", 38, 95)
+        b:SetPoint("BOTTOMLEFT", 38, 120)
         b.text:SetText(L["Ignore Import/Export Action"])
         b:SetScript("OnClick", updateButton)
         ignoreActionCheckbox = b
@@ -117,7 +117,7 @@ do
         local b = CreateFrame("CheckButton", nil, f, "UICheckButtonTemplate")
         b.text = b:CreateFontString(nil, "OVERLAY", "GameFontNormal")
         b.text:SetPoint("LEFT", b, "RIGHT", 0, 1)
-        b:SetPoint("BOTTOMLEFT", 38, 70)
+        b:SetPoint("BOTTOMLEFT", 38, 95)
         b.text:SetText(L["Ignore Import/Export Key Binding"])
         b:SetScript("OnClick", updateButton)
         ignoreBindingCheckbox = b
@@ -127,7 +127,7 @@ do
         local b = CreateFrame("CheckButton", nil, f, "UICheckButtonTemplate")
         b.text = b:CreateFontString(nil, "OVERLAY", "GameFontNormal")
         b.text:SetPoint("LEFT", b, "RIGHT", 0, 1)
-        b:SetPoint("BOTTOMLEFT", 38, 45)
+        b:SetPoint("BOTTOMLEFT", 38, 70)
         b.text:SetText(L["Ignore Import/Export Macro"])
         b:SetScript("OnClick", updateButton)
         ignoreMacroCheckbox = b
@@ -137,7 +137,7 @@ do
         local b = CreateFrame("CheckButton", nil, f, "UICheckButtonTemplate")
         b.text = b:CreateFontString(nil, "OVERLAY", "GameFontNormal")
         b.text:SetPoint("LEFT", b, "RIGHT", 0, 1)
-        b:SetPoint("BOTTOMLEFT", 38, 20)
+        b:SetPoint("BOTTOMLEFT", 38, 45)
         b.text:SetText(L["Ignore General Macros"])
         b:SetScript("OnClick", updateButton)
         ignoreGeneralMacroCheckbox = b
@@ -147,7 +147,7 @@ do
         local b = CreateFrame("CheckButton", nil, f, "UICheckButtonTemplate")
         b.text = b:CreateFontString(nil, "OVERLAY", "GameFontNormal")
         b.text:SetPoint("LEFT", b, "RIGHT", 0, 1)
-        b:SetPoint("BOTTOMLEFT", 340, 95)
+        b:SetPoint("BOTTOMLEFT", 340, 120)
         b.text:SetText(L["Clear Action before applying"])
         clearActionCheckbox = b
     end
@@ -156,7 +156,7 @@ do
         local b = CreateFrame("CheckButton", nil, f, "UICheckButtonTemplate")
         b.text = b:CreateFontString(nil, "OVERLAY", "GameFontNormal")
         b.text:SetPoint("LEFT", b, "RIGHT", 0, 1)
-        b:SetPoint("BOTTOMLEFT", 340, 70)
+        b:SetPoint("BOTTOMLEFT", 340, 95)
         b.text:SetText(L["Clear Binding before applying"])
         clearBindingCheckbox = b
     end
@@ -165,7 +165,7 @@ do
         local b = CreateFrame("CheckButton", nil, f, "UICheckButtonTemplate")
         b.text = b:CreateFontString(nil, "OVERLAY", "GameFontNormal")
         b.text:SetPoint("LEFT", b, "RIGHT", 0, 1)
-        b:SetPoint("BOTTOMLEFT", 340, 45)
+        b:SetPoint("BOTTOMLEFT", 340, 70)
         b.text:SetText(L["Clear Macro before applying"])
         clearMacroCheckbox = b
     end

--- a/gui.lua
+++ b/gui.lua
@@ -81,24 +81,17 @@ end
 local gatherCheckboxOptions
 local importButton
 local exportButton
+local ignoreActionCheckbox
+local ignoreBindingCheckbox
+local ignoreMacroCheckbox
+local ignoreGeneralMacroCheckbox
+local clearActionCheckbox
+local clearBindingCheckbox
+local clearMacroCheckbox
 
 do
     MyslotSettings = MyslotSettings or {}
-    MyslotSettings.ignoreAction = MyslotSettings.ignoreAction or false
-    MyslotSettings.ignoreBinding = MyslotSettings.ignoreBinding or false
-    MyslotSettings.ignoreMacro = MyslotSettings.ignoreMacro or false
-    MyslotSettings.ignoreGeneralMacro = MyslotSettings.ignoreGeneralMacro or false
-    MyslotSettings.clearAction = MyslotSettings.clearAction or false
-    MyslotSettings.clearBinding = MyslotSettings.clearBinding or false
-    MyslotSettings.clearMacro = MyslotSettings.clearMacro or false
 
-    local ignoreActionCheckbox
-    local ignoreBindingCheckbox
-    local ignoreMacroCheckbox
-    local ignoreGeneralMacroCheckbox
-    local clearActionCheckbox
-    local clearBindingCheckbox
-    local clearMacroCheckbox
 
     local function updateButton()
         local disable = ignoreActionCheckbox:GetChecked() and ignoreBindingCheckbox:GetChecked() and ignoreMacroCheckbox:GetChecked()
@@ -515,6 +508,23 @@ RegEvent("ADDON_LOADED", function()
     MyslotSettings = MyslotSettings or {}
     MyslotSettings.minimap = MyslotSettings.minimap or { hide = false }
     local config = MyslotSettings.minimap
+
+    -- Set Checkbox states
+    MyslotSettings.ignoreAction = MyslotSettings.ignoreAction or false
+    MyslotSettings.ignoreBinding = MyslotSettings.ignoreBinding or false
+    MyslotSettings.ignoreMacro = MyslotSettings.ignoreMacro or false
+    MyslotSettings.ignoreGeneralMacro = MyslotSettings.ignoreGeneralMacro or false
+    MyslotSettings.clearAction = MyslotSettings.clearAction or false
+    MyslotSettings.clearBinding = MyslotSettings.clearBinding or false
+    MyslotSettings.clearMacro = MyslotSettings.clearMacro or false
+
+    ignoreActionCheckbox:SetChecked(MyslotSettings.ignoreAction)
+    ignoreBindingCheckbox:SetChecked(MyslotSettings.ignoreBinding)
+    ignoreMacroCheckbox:SetChecked(MyslotSettings.ignoreMacro)
+    ignoreGeneralMacroCheckbox:SetChecked(MyslotSettings.ignoreGeneralMacro)
+    clearActionCheckbox:SetChecked(MyslotSettings.clearAction)
+    clearBindingCheckbox:SetChecked(MyslotSettings.clearBinding)
+    clearMacroCheckbox:SetChecked(MyslotSettings.clearMacro)
 
     icon:Register("Myslot", ldb:NewDataObject("Myslot", {
             icon = "Interface\\MacroFrame\\MacroFrame-Icon",

--- a/gui.lua
+++ b/gui.lua
@@ -83,6 +83,15 @@ local importButton
 local exportButton
 
 do
+    MyslotSettings = MyslotSettings or {}
+    MyslotSettings.ignoreAction = MyslotSettings.ignoreAction or false
+    MyslotSettings.ignoreBinding = MyslotSettings.ignoreBinding or false
+    MyslotSettings.ignoreMacro = MyslotSettings.ignoreMacro or false
+    MyslotSettings.ignoreGeneralMacro = MyslotSettings.ignoreGeneralMacro or false
+    MyslotSettings.clearAction = MyslotSettings.clearAction or false
+    MyslotSettings.clearBinding = MyslotSettings.clearBinding or false
+    MyslotSettings.clearMacro = MyslotSettings.clearMacro or false
+
     local ignoreActionCheckbox
     local ignoreBindingCheckbox
     local ignoreMacroCheckbox
@@ -109,7 +118,11 @@ do
         b.text:SetPoint("LEFT", b, "RIGHT", 0, 1)
         b:SetPoint("BOTTOMLEFT", 38, 120)
         b.text:SetText(L["Ignore Import/Export Action"])
-        b:SetScript("OnClick", updateButton)
+        b:SetChecked(MyslotSettings.ignoreAction)
+        b:SetScript("OnClick", function(self) 
+            MyslotSettings.ignoreAction = self:GetChecked()
+            updateButton()
+        end)
         ignoreActionCheckbox = b
     end
 
@@ -119,7 +132,11 @@ do
         b.text:SetPoint("LEFT", b, "RIGHT", 0, 1)
         b:SetPoint("BOTTOMLEFT", 38, 95)
         b.text:SetText(L["Ignore Import/Export Key Binding"])
-        b:SetScript("OnClick", updateButton)
+        b:SetChecked(MyslotSettings.ignoreBinding)
+        b:SetScript("OnClick", function(self) 
+            MyslotSettings.ignoreBinding = self:GetChecked()
+            updateButton()
+        end)
         ignoreBindingCheckbox = b
     end
 
@@ -129,7 +146,11 @@ do
         b.text:SetPoint("LEFT", b, "RIGHT", 0, 1)
         b:SetPoint("BOTTOMLEFT", 38, 70)
         b.text:SetText(L["Ignore Import/Export Macro"])
-        b:SetScript("OnClick", updateButton)
+        b:SetChecked(MyslotSettings.ignoreMacro)
+        b:SetScript("OnClick", function(self) 
+            MyslotSettings.ignoreMacro = self:GetChecked()
+            updateButton()
+        end)
         ignoreMacroCheckbox = b
     end
 
@@ -139,7 +160,11 @@ do
         b.text:SetPoint("LEFT", b, "RIGHT", 0, 1)
         b:SetPoint("BOTTOMLEFT", 38, 45)
         b.text:SetText(L["Ignore General Macros"])
-        b:SetScript("OnClick", updateButton)
+        b:SetChecked(MyslotSettings.ignoreGeneralMacro)
+        b:SetScript("OnClick", function(self) 
+            MyslotSettings.ignoreGeneralMacro = self:GetChecked()
+            updateButton()
+        end)
         ignoreGeneralMacroCheckbox = b
     end
 
@@ -149,6 +174,10 @@ do
         b.text:SetPoint("LEFT", b, "RIGHT", 0, 1)
         b:SetPoint("BOTTOMLEFT", 340, 120)
         b.text:SetText(L["Clear Action before applying"])
+        b:SetChecked(MyslotSettings.clearAction)
+        b:SetScript("OnClick", function(self) 
+            MyslotSettings.clearAction = self:GetChecked()
+        end)
         clearActionCheckbox = b
     end
 
@@ -158,6 +187,10 @@ do
         b.text:SetPoint("LEFT", b, "RIGHT", 0, 1)
         b:SetPoint("BOTTOMLEFT", 340, 95)
         b.text:SetText(L["Clear Binding before applying"])
+        b:SetChecked(MyslotSettings.clearBinding)
+        b:SetScript("OnClick", function(self) 
+            MyslotSettings.clearBinding = self:GetChecked()
+        end)
         clearBindingCheckbox = b
     end
 
@@ -167,6 +200,10 @@ do
         b.text:SetPoint("LEFT", b, "RIGHT", 0, 1)
         b:SetPoint("BOTTOMLEFT", 340, 70)
         b.text:SetText(L["Clear Macro before applying"])
+        b:SetChecked(MyslotSettings.clearMacro)
+        b:SetScript("OnClick", function(self) 
+            MyslotSettings.clearMacro = self:GetChecked()
+        end)
         clearMacroCheckbox = b
     end
 

--- a/options.lua
+++ b/options.lua
@@ -112,7 +112,7 @@ StaticPopupDialogs["MYSLOT_CONFIRM_CLEAR"] = {
         local tx = self.editBox:GetText()
 
         if tx == data then
-            MySlot:Clear(data)
+            MySlot:Clear(data, nil)
         else
             MySlot:Print(L["Please type %s to confirm"]:format(data))
         end


### PR DESCRIPTION
Hello!

I was finding it frustrating that I was losing general macros on characters that didn't use Myslot when using the ClearMacro functionality.

Added an option to ignore general macros and only import/export/clear character specific macros