### PR TITLE
Fix lua errors in TWW Beta

### DIFF
--- a/options.lua
+++ b/options.lua
@@ -4,7 +4,7 @@ local RegEvent = MySlot.regevent
 
 
 local f = CreateFrame("Frame", nil, UIParent)
-local category, layout = Settings.RegisterCanvasLayoutCategory(f, "Myslot");
+local category, layout = Settings.RegisterCanvasLayoutCategory(f, L["Myslot"]);
 
 Settings.RegisterAddOnCategory(category);
 

--- a/options.lua
+++ b/options.lua
@@ -4,8 +4,9 @@ local RegEvent = MySlot.regevent
 
 
 local f = CreateFrame("Frame", nil, UIParent)
-f.name = L["Myslot"]
-InterfaceOptions_AddCategory(f)
+local category, layout = Settings.RegisterCanvasLayoutCategory(f, "Myslot");
+
+Settings.RegisterAddOnCategory(category);
 
 RegEvent("ADDON_LOADED", function()
     do


### PR DESCRIPTION
The API being used to display an options panel has been deprecated in Dragonflight and removed on a TWW Beta. This PR includes a newer version of the API used for the same purpose. I manually checked it both on beta and on retail.