### PR TITLE
Add Account/Character Macro feature.

### DIFF
--- a/Myslot.lua
+++ b/Myslot.lua
@@ -594,7 +594,12 @@ function MySlot:RecoverData(msg, opt)
                         elseif slotType == MYSLOT_ITEM then
                             PickupItem(index)
                         elseif slotType == MYSLOT_MACRO then
-                            local macroid = self:FindOrCreateMacro(macro[index])
+                            local macroid
+                            if opt.ignoreGeneralMacro and index <= MAX_ACCOUNT_MACROS then
+                                macroid = index
+                            else
+                                macroid = self:FindOrCreateMacro(macro[index])
+                            end
 
                             if curType ~= MYSLOT_MACRO or curIndex ~= index then
                                 PickupMacro(macroid)

--- a/Myslot.lua
+++ b/Myslot.lua
@@ -540,17 +540,15 @@ function MySlot:RecoverData(msg, opt)
             ["icon"] = icon,
             ["body"] = body,
         }
-        if (not opt.ignoreGeneralMacros and m.id <= MAX_ACCOUNT_MACROS) or (not opt.ignoreCharacterMacros and m.id > MAX_ACCOUNT_MACROS) then
+        if (not opt.ignoreAccountMacros and m.id <= MAX_ACCOUNT_MACROS) or (not opt.ignoreCharacterMacros and m.id > MAX_ACCOUNT_MACROS) then
             self:FindOrCreateMacro(macro[macroId])
         end
     end
     -- }}} Macro
 
+    -- Action Bars
+    MySlot:Clear("ACTION", opt)
     if (not opt.ignoreAction) then
-        if opt.clearAction then
-            MySlot:Clear("ACTION", opt)
-        end
-
         local slotBucket = {}
 
         for _, s in pairs(msg.slot or {}) do
@@ -594,7 +592,9 @@ function MySlot:RecoverData(msg, opt)
                             local macroId = self:FindMacro(macro[index])
 
                             if macroId and (curType ~= MYSLOT_MACRO or curIndex ~= index) then
-                                PickupMacro(macroid)
+                                PickupMacro(macroId)
+                            else
+                                MySlot:Print("Could not find macro [id=" .. index .. "] for Action Bar [slot="..slotId.."]. Ignoring")
                             end
                         elseif slotType == MYSLOT_SUMMONPET and strindex and strindex ~= curIndex then
                             C_PetJournal.PickupPet(strindex, false)
@@ -640,11 +640,9 @@ function MySlot:RecoverData(msg, opt)
         end
     end
 
+    -- Key Binds
+    MySlot:Clear("BINDING", opt)
     if not opt.ignoreBinding then
-        if opt.clearBinding then
-            MySlot:Clear("BINDING", opt)
-        end
-
         for _, b in pairs(msg.bind or {}) do
             local command = b.command
             if b.id ~= MYSLOT_BIND_CUSTOM_FLAG then
@@ -676,7 +674,7 @@ function MySlot:RecoverData(msg, opt)
 end
 
 function MySlot:Clear(what, opt)
-    if what == "ACTION" then
+    if what == "ACTION" and opt and opt.clearAction then
         for i = 1, MYSLOT_MAX_ACTIONBAR do
             PickupAction(i)
             ClearCursor()
@@ -686,21 +684,21 @@ function MySlot:Clear(what, opt)
         local endIndex = 1
 
         -- No clear necessary
-        if opt and not opt.clearGeneralMacros and not opt.clearCharacterMacros then return end
+        if opt and not opt.clearAccountMacros and not opt.clearCharacterMacros then return end
 
         -- If you dont want to clear character macros, start at end of general macros
         if opt and not opt.clearCharacterMacros then
             initIndex = MAX_ACCOUNT_MACROS
         end
         -- If you dont want to clear general macros, end at start of character macros
-        if opt and not opt.clearGeneralMacros then
+        if opt and not opt.clearAccountMacros then
             endIndex = MAX_ACCOUNT_MACROS + 1
         end
 
         for i = initIndex, endIndex, -1 do
             DeleteMacro(i)
         end
-    elseif what == "BINDING" then
+    elseif what == "BINDING" and opt and opt.clearBinding then
         for i = 1, GetNumBindings() do
             local _, _, key1, key2 = GetBinding(i)
 

--- a/Myslot.lua
+++ b/Myslot.lua
@@ -525,7 +525,7 @@ function MySlot:RecoverData(msg, opt)
     local macro = {}
     if not opt.ignoreMacro then
         if opt.clearMacro then
-            MySlot:Clear("MACRO")
+            MySlot:Clear("MACRO", opt)
         end
 
         for _, m in pairs(msg.macro or {}) do
@@ -551,7 +551,7 @@ function MySlot:RecoverData(msg, opt)
 
     if (not opt.ignoreAction) then
         if opt.clearAction then
-            MySlot:Clear("ACTION")
+            MySlot:Clear("ACTION", opt)
         end
 
         local slotBucket = {}
@@ -645,7 +645,7 @@ function MySlot:RecoverData(msg, opt)
 
     if not opt.ignoreBinding then
         if opt.clearBinding then
-            MySlot:Clear("BINDING")
+            MySlot:Clear("BINDING", opt)
         end
 
         for _, b in pairs(msg.bind or {}) do
@@ -678,7 +678,7 @@ function MySlot:RecoverData(msg, opt)
     MySlot:Print(L["All slots were restored"])
 end
 
-function MySlot:Clear(what)
+function MySlot:Clear(what, opt)
     if what == "ACTION" then
         for i = 1, MYSLOT_MAX_ACTIONBAR do
             PickupAction(i)
@@ -686,7 +686,7 @@ function MySlot:Clear(what)
         end
     elseif what == "MACRO" then
         local initIndex = 1
-        if opt.ignoreGeneralMacro then
+        if opt and opt.ignoreGeneralMacro then
             initIndex = MAX_ACCOUNT_MACROS + 1
         end
 

--- a/Myslot.lua
+++ b/Myslot.lua
@@ -270,7 +270,12 @@ function MySlot:Export(opt)
     msg.macro = {}
 
     if not opt.ignoreMacro then
-        for i = 1, MAX_ACCOUNT_MACROS + MAX_CHARACTER_MACROS do
+        local initIndex = 1
+        if opt.ignoreGeneralMacro then
+            initIndex = MAX_ACCOUNT_MACROS + 1
+        end
+
+        for i = initIndex, MAX_ACCOUNT_MACROS + MAX_CHARACTER_MACROS do
             local m = self:GetMacroInfo(i)
             if m then
                 msg.macro[#msg.macro + 1] = m
@@ -524,20 +529,22 @@ function MySlot:RecoverData(msg, opt)
         end
 
         for _, m in pairs(msg.macro or {}) do
-            local macroId = m.id
-            local icon = m.icon
+            if not opt.ignoreGeneralMacro or m.id > MAX_ACCOUNT_MACROS then
+                local macroId = m.id
+                local icon = m.icon
 
-            local name = m.name
-            local body = m.body
+                local name = m.name
+                local body = m.body
 
-            macro[macroId] = {
-                ["oldid"] = macroId,
-                ["name"] = name,
-                ["icon"] = icon,
-                ["body"] = body,
-            }
+                macro[macroId] = {
+                    ["oldid"] = macroId,
+                    ["name"] = name,
+                    ["icon"] = icon,
+                    ["body"] = body,
+                }
 
-            self:FindOrCreateMacro(macro[macroId])
+                self:FindOrCreateMacro(macro[macroId])
+            end
         end
     end
     -- }}} Macro
@@ -678,7 +685,12 @@ function MySlot:Clear(what)
             ClearCursor()
         end
     elseif what == "MACRO" then
-        for i = MAX_ACCOUNT_MACROS + MAX_CHARACTER_MACROS, 1, -1 do
+        local initIndex = 1
+        if opt.ignoreGeneralMacro then
+            initIndex = MAX_ACCOUNT_MACROS + 1
+        end
+
+        for i = MAX_ACCOUNT_MACROS + MAX_CHARACTER_MACROS, initIndex, -1 do
             DeleteMacro(i)
         end
     elseif what == "BINDING" then

--- a/Myslot.lua
+++ b/Myslot.lua
@@ -591,10 +591,10 @@ function MySlot:RecoverData(msg, opt)
                         elseif slotType == MYSLOT_MACRO then
                             local macroId = self:FindMacro(macro[index])
 
-                            if macroId and (curType ~= MYSLOT_MACRO or curIndex ~= index) then
-                                PickupMacro(macroId)
-                            else
+                            if not macroId then
                                 MySlot:Print("Could not find macro [id=" .. index .. "] for Action Bar [slot="..slotId.."]. Ignoring")
+                            elseif macroId and (curType ~= MYSLOT_MACRO or curIndex ~= index) then
+                                PickupMacro(macroId)
                             end
                         elseif slotType == MYSLOT_SUMMONPET and strindex and strindex ~= curIndex then
                             C_PetJournal.PickupPet(strindex, false)

--- a/gui.lua
+++ b/gui.lua
@@ -86,6 +86,7 @@ do
     local ignoreActionCheckbox
     local ignoreBindingCheckbox
     local ignoreMacroCheckbox
+    local ignoreGeneralMacroCheckbox
     local clearActionCheckbox
     local clearBindingCheckbox
     local clearMacroCheckbox
@@ -136,6 +137,16 @@ do
         local b = CreateFrame("CheckButton", nil, f, "UICheckButtonTemplate")
         b.text = b:CreateFontString(nil, "OVERLAY", "GameFontNormal")
         b.text:SetPoint("LEFT", b, "RIGHT", 0, 1)
+        b:SetPoint("BOTTOMLEFT", 38, 20)
+        b.text:SetText(L["Ignore General Macros"])
+        b:SetScript("OnClick", updateButton)
+        ignoreGeneralMacroCheckbox = b
+    end
+
+    do
+        local b = CreateFrame("CheckButton", nil, f, "UICheckButtonTemplate")
+        b.text = b:CreateFontString(nil, "OVERLAY", "GameFontNormal")
+        b.text:SetPoint("LEFT", b, "RIGHT", 0, 1)
         b:SetPoint("BOTTOMLEFT", 340, 95)
         b.text:SetText(L["Clear Action before applying"])
         clearActionCheckbox = b
@@ -166,6 +177,7 @@ do
                 ignoreAction = ignoreActionCheckbox:GetChecked(),
                 ignoreBinding = ignoreBindingCheckbox:GetChecked(),
                 ignoreMacro = ignoreMacroCheckbox:GetChecked(),
+                ignoreGeneralMacro = ignoreGeneralMacroCheckbox:GetChecked(),
                 clearAction = clearActionCheckbox:GetChecked(),
                 clearBinding = clearBindingCheckbox:GetChecked(),
                 clearMacro = clearMacroCheckbox:GetChecked(),
@@ -521,6 +533,7 @@ SlashCmdList["MYSLOT"] = function(msg, editbox)
                 ignoreAction = false,
                 ignoreBinding = false,
                 ignoreMacro = false,
+                ignoreGeneralMacro = false,
                 clearAction = false,
                 clearBinding = false,
                 clearMacro = false,

--- a/gui.lua
+++ b/gui.lua
@@ -7,7 +7,7 @@ local MAX_PROFILES_COUNT = 50
 
 local f = CreateFrame("Frame", nil, UIParent, BackdropTemplateMixin and "BackdropTemplate" or nil)
 f:SetWidth(650)
-f:SetHeight(600)
+f:SetHeight(625)
 f:SetBackdrop({
     bgFile = "Interface\\DialogFrame\\UI-DialogBox-Background",
     edgeFile = "Interface\\DialogFrame\\UI-DialogBox-Border",
@@ -107,7 +107,7 @@ do
         local b = CreateFrame("CheckButton", nil, f, "UICheckButtonTemplate")
         b.text = b:CreateFontString(nil, "OVERLAY", "GameFontNormal")
         b.text:SetPoint("LEFT", b, "RIGHT", 0, 1)
-        b:SetPoint("BOTTOMLEFT", 38, 95)
+        b:SetPoint("BOTTOMLEFT", 38, 120)
         b.text:SetText(L["Ignore Import/Export Action"])
         b:SetScript("OnClick", updateButton)
         ignoreActionCheckbox = b
@@ -117,7 +117,7 @@ do
         local b = CreateFrame("CheckButton", nil, f, "UICheckButtonTemplate")
         b.text = b:CreateFontString(nil, "OVERLAY", "GameFontNormal")
         b.text:SetPoint("LEFT", b, "RIGHT", 0, 1)
-        b:SetPoint("BOTTOMLEFT", 38, 70)
+        b:SetPoint("BOTTOMLEFT", 38, 95)
         b.text:SetText(L["Ignore Import/Export Key Binding"])
         b:SetScript("OnClick", updateButton)
         ignoreBindingCheckbox = b
@@ -127,7 +127,7 @@ do
         local b = CreateFrame("CheckButton", nil, f, "UICheckButtonTemplate")
         b.text = b:CreateFontString(nil, "OVERLAY", "GameFontNormal")
         b.text:SetPoint("LEFT", b, "RIGHT", 0, 1)
-        b:SetPoint("BOTTOMLEFT", 38, 45)
+        b:SetPoint("BOTTOMLEFT", 38, 70)
         b.text:SetText(L["Ignore Import/Export Macro"])
         b:SetScript("OnClick", updateButton)
         ignoreMacroCheckbox = b
@@ -137,7 +137,7 @@ do
         local b = CreateFrame("CheckButton", nil, f, "UICheckButtonTemplate")
         b.text = b:CreateFontString(nil, "OVERLAY", "GameFontNormal")
         b.text:SetPoint("LEFT", b, "RIGHT", 0, 1)
-        b:SetPoint("BOTTOMLEFT", 38, 20)
+        b:SetPoint("BOTTOMLEFT", 38, 45)
         b.text:SetText(L["Ignore General Macros"])
         b:SetScript("OnClick", updateButton)
         ignoreGeneralMacroCheckbox = b
@@ -147,7 +147,7 @@ do
         local b = CreateFrame("CheckButton", nil, f, "UICheckButtonTemplate")
         b.text = b:CreateFontString(nil, "OVERLAY", "GameFontNormal")
         b.text:SetPoint("LEFT", b, "RIGHT", 0, 1)
-        b:SetPoint("BOTTOMLEFT", 340, 95)
+        b:SetPoint("BOTTOMLEFT", 340, 120)
         b.text:SetText(L["Clear Action before applying"])
         clearActionCheckbox = b
     end
@@ -156,7 +156,7 @@ do
         local b = CreateFrame("CheckButton", nil, f, "UICheckButtonTemplate")
         b.text = b:CreateFontString(nil, "OVERLAY", "GameFontNormal")
         b.text:SetPoint("LEFT", b, "RIGHT", 0, 1)
-        b:SetPoint("BOTTOMLEFT", 340, 70)
+        b:SetPoint("BOTTOMLEFT", 340, 95)
         b.text:SetText(L["Clear Binding before applying"])
         clearBindingCheckbox = b
     end
@@ -165,7 +165,7 @@ do
         local b = CreateFrame("CheckButton", nil, f, "UICheckButtonTemplate")
         b.text = b:CreateFontString(nil, "OVERLAY", "GameFontNormal")
         b.text:SetPoint("LEFT", b, "RIGHT", 0, 1)
-        b:SetPoint("BOTTOMLEFT", 340, 45)
+        b:SetPoint("BOTTOMLEFT", 340, 70)
         b.text:SetText(L["Clear Macro before applying"])
         clearMacroCheckbox = b
     end

--- a/gui.lua
+++ b/gui.lua
@@ -81,24 +81,17 @@ end
 local gatherCheckboxOptions
 local importButton
 local exportButton
+local ignoreActionCheckbox
+local ignoreBindingCheckbox
+local ignoreMacroCheckbox
+local ignoreGeneralMacroCheckbox
+local clearActionCheckbox
+local clearBindingCheckbox
+local clearMacroCheckbox
 
 do
     MyslotSettings = MyslotSettings or {}
-    MyslotSettings.ignoreAction = MyslotSettings.ignoreAction or false
-    MyslotSettings.ignoreBinding = MyslotSettings.ignoreBinding or false
-    MyslotSettings.ignoreMacro = MyslotSettings.ignoreMacro or false
-    MyslotSettings.ignoreGeneralMacro = MyslotSettings.ignoreGeneralMacro or false
-    MyslotSettings.clearAction = MyslotSettings.clearAction or false
-    MyslotSettings.clearBinding = MyslotSettings.clearBinding or false
-    MyslotSettings.clearMacro = MyslotSettings.clearMacro or false
 
-    local ignoreActionCheckbox
-    local ignoreBindingCheckbox
-    local ignoreMacroCheckbox
-    local ignoreGeneralMacroCheckbox
-    local clearActionCheckbox
-    local clearBindingCheckbox
-    local clearMacroCheckbox
 
     local function updateButton()
         local disable = ignoreActionCheckbox:GetChecked() and ignoreBindingCheckbox:GetChecked() and ignoreMacroCheckbox:GetChecked()
@@ -515,6 +508,23 @@ RegEvent("ADDON_LOADED", function()
     MyslotSettings = MyslotSettings or {}
     MyslotSettings.minimap = MyslotSettings.minimap or { hide = false }
     local config = MyslotSettings.minimap
+
+    -- Set Checkbox states
+    MyslotSettings.ignoreAction = MyslotSettings.ignoreAction or false
+    MyslotSettings.ignoreBinding = MyslotSettings.ignoreBinding or false
+    MyslotSettings.ignoreMacro = MyslotSettings.ignoreMacro or false
+    MyslotSettings.ignoreGeneralMacro = MyslotSettings.ignoreGeneralMacro or false
+    MyslotSettings.clearAction = MyslotSettings.clearAction or false
+    MyslotSettings.clearBinding = MyslotSettings.clearBinding or false
+    MyslotSettings.clearMacro = MyslotSettings.clearMacro or false
+
+    ignoreActionCheckbox:SetChecked(MyslotSettings.ignoreAction)
+    ignoreBindingCheckbox:SetChecked(MyslotSettings.ignoreBinding)
+    ignoreMacroCheckbox:SetChecked(MyslotSettings.ignoreMacro)
+    ignoreGeneralMacroCheckbox:SetChecked(MyslotSettings.ignoreGeneralMacro)
+    clearActionCheckbox:SetChecked(MyslotSettings.clearAction)
+    clearBindingCheckbox:SetChecked(MyslotSettings.clearBinding)
+    clearMacroCheckbox:SetChecked(MyslotSettings.clearMacro)
 
     icon:Register("Myslot", ldb:NewDataObject("Myslot", {
             icon = "Interface\\MacroFrame\\MacroFrame-Icon",

--- a/gui.lua
+++ b/gui.lua
@@ -83,6 +83,15 @@ local importButton
 local exportButton
 
 do
+    MyslotSettings = MyslotSettings or {}
+    MyslotSettings.ignoreAction = MyslotSettings.ignoreAction or false
+    MyslotSettings.ignoreBinding = MyslotSettings.ignoreBinding or false
+    MyslotSettings.ignoreMacro = MyslotSettings.ignoreMacro or false
+    MyslotSettings.ignoreGeneralMacro = MyslotSettings.ignoreGeneralMacro or false
+    MyslotSettings.clearAction = MyslotSettings.clearAction or false
+    MyslotSettings.clearBinding = MyslotSettings.clearBinding or false
+    MyslotSettings.clearMacro = MyslotSettings.clearMacro or false
+
     local ignoreActionCheckbox
     local ignoreBindingCheckbox
     local ignoreMacroCheckbox
@@ -109,7 +118,11 @@ do
         b.text:SetPoint("LEFT", b, "RIGHT", 0, 1)
         b:SetPoint("BOTTOMLEFT", 38, 120)
         b.text:SetText(L["Ignore Import/Export Action"])
-        b:SetScript("OnClick", updateButton)
+        b:SetChecked(MyslotSettings.ignoreAction)
+        b:SetScript("OnClick", function(self) 
+            MyslotSettings.ignoreAction = self:GetChecked()
+            updateButton()
+        end)
         ignoreActionCheckbox = b
     end
 
@@ -119,7 +132,11 @@ do
         b.text:SetPoint("LEFT", b, "RIGHT", 0, 1)
         b:SetPoint("BOTTOMLEFT", 38, 95)
         b.text:SetText(L["Ignore Import/Export Key Binding"])
-        b:SetScript("OnClick", updateButton)
+        b:SetChecked(MyslotSettings.ignoreBinding)
+        b:SetScript("OnClick", function(self) 
+            MyslotSettings.ignoreBinding = self:GetChecked()
+            updateButton()
+        end)
         ignoreBindingCheckbox = b
     end
 
@@ -129,7 +146,11 @@ do
         b.text:SetPoint("LEFT", b, "RIGHT", 0, 1)
         b:SetPoint("BOTTOMLEFT", 38, 70)
         b.text:SetText(L["Ignore Import/Export Macro"])
-        b:SetScript("OnClick", updateButton)
+        b:SetChecked(MyslotSettings.ignoreMacro)
+        b:SetScript("OnClick", function(self) 
+            MyslotSettings.ignoreMacro = self:GetChecked()
+            updateButton()
+        end)
         ignoreMacroCheckbox = b
     end
 
@@ -139,7 +160,11 @@ do
         b.text:SetPoint("LEFT", b, "RIGHT", 0, 1)
         b:SetPoint("BOTTOMLEFT", 38, 45)
         b.text:SetText(L["Ignore General Macros"])
-        b:SetScript("OnClick", updateButton)
+        b:SetChecked(MyslotSettings.ignoreGeneralMacro)
+        b:SetScript("OnClick", function(self) 
+            MyslotSettings.ignoreGeneralMacro = self:GetChecked()
+            updateButton()
+        end)
         ignoreGeneralMacroCheckbox = b
     end
 
@@ -149,6 +174,10 @@ do
         b.text:SetPoint("LEFT", b, "RIGHT", 0, 1)
         b:SetPoint("BOTTOMLEFT", 340, 120)
         b.text:SetText(L["Clear Action before applying"])
+        b:SetChecked(MyslotSettings.clearAction)
+        b:SetScript("OnClick", function(self) 
+            MyslotSettings.clearAction = self:GetChecked()
+        end)
         clearActionCheckbox = b
     end
 
@@ -158,6 +187,10 @@ do
         b.text:SetPoint("LEFT", b, "RIGHT", 0, 1)
         b:SetPoint("BOTTOMLEFT", 340, 95)
         b.text:SetText(L["Clear Binding before applying"])
+        b:SetChecked(MyslotSettings.clearBinding)
+        b:SetScript("OnClick", function(self) 
+            MyslotSettings.clearBinding = self:GetChecked()
+        end)
         clearBindingCheckbox = b
     end
 
@@ -167,6 +200,10 @@ do
         b.text:SetPoint("LEFT", b, "RIGHT", 0, 1)
         b:SetPoint("BOTTOMLEFT", 340, 70)
         b.text:SetText(L["Clear Macro before applying"])
+        b:SetChecked(MyslotSettings.clearMacro)
+        b:SetScript("OnClick", function(self) 
+            MyslotSettings.clearMacro = self:GetChecked()
+        end)
         clearMacroCheckbox = b
     end
 

--- a/gui.lua
+++ b/gui.lua
@@ -81,13 +81,15 @@ end
 local gatherCheckboxOptions
 local importButton
 local exportButton
+
 local ignoreActionCheckbox
 local ignoreBindingCheckbox
-local ignoreMacroCheckbox
 local ignoreGeneralMacroCheckbox
+local ignoreCharacterMacroCheckbox
 local clearActionCheckbox
 local clearBindingCheckbox
-local clearMacroCheckbox
+local clearGeneralMacroCheckbox
+local clearCharacterMacroCheckbox
 
 do
     MyslotSettings = MyslotSettings or {}
@@ -105,12 +107,23 @@ do
         end
     end
 
+    -- Set Option Titles
+    -- do
+    --     local x = f:CreateFontString(nil, "ARTWORK", "GameFontNormalLarge")
+    --     x:SetText("Import Options")
+    --     x:SetPoint("TOPLEFT", 36, -360)
+
+    --     x = f:CreateFontString(nil, "ARTWORK", "GameFontNormalLarge")
+    --     x:SetText("Clear on Import")
+    --     x:SetPoint("TOPLEFT", 336, -360)
+    -- end
+
     do
         local b = CreateFrame("CheckButton", nil, f, "UICheckButtonTemplate")
         b.text = b:CreateFontString(nil, "OVERLAY", "GameFontNormal")
         b.text:SetPoint("LEFT", b, "RIGHT", 0, 1)
         b:SetPoint("BOTTOMLEFT", 38, 120)
-        b.text:SetText(L["Ignore Import/Export Action"])
+        b.text:SetText(L["Ignore Action Bars"])
         b:SetChecked(MyslotSettings.ignoreAction)
         b:SetScript("OnClick", function(self) 
             MyslotSettings.ignoreAction = self:GetChecked()
@@ -124,7 +137,7 @@ do
         b.text = b:CreateFontString(nil, "OVERLAY", "GameFontNormal")
         b.text:SetPoint("LEFT", b, "RIGHT", 0, 1)
         b:SetPoint("BOTTOMLEFT", 38, 95)
-        b.text:SetText(L["Ignore Import/Export Key Binding"])
+        b.text:SetText(L["Ignore Key Bindings"])
         b:SetChecked(MyslotSettings.ignoreBinding)
         b:SetScript("OnClick", function(self) 
             MyslotSettings.ignoreBinding = self:GetChecked()
@@ -138,24 +151,10 @@ do
         b.text = b:CreateFontString(nil, "OVERLAY", "GameFontNormal")
         b.text:SetPoint("LEFT", b, "RIGHT", 0, 1)
         b:SetPoint("BOTTOMLEFT", 38, 70)
-        b.text:SetText(L["Ignore Import/Export Macro"])
-        b:SetChecked(MyslotSettings.ignoreMacro)
-        b:SetScript("OnClick", function(self) 
-            MyslotSettings.ignoreMacro = self:GetChecked()
-            updateButton()
-        end)
-        ignoreMacroCheckbox = b
-    end
-
-    do
-        local b = CreateFrame("CheckButton", nil, f, "UICheckButtonTemplate")
-        b.text = b:CreateFontString(nil, "OVERLAY", "GameFontNormal")
-        b.text:SetPoint("LEFT", b, "RIGHT", 0, 1)
-        b:SetPoint("BOTTOMLEFT", 38, 45)
         b.text:SetText(L["Ignore General Macros"])
-        b:SetChecked(MyslotSettings.ignoreGeneralMacro)
+        b:SetChecked(MyslotSettings.ignoreGeneralMacros)
         b:SetScript("OnClick", function(self) 
-            MyslotSettings.ignoreGeneralMacro = self:GetChecked()
+            MyslotSettings.ignoreGeneralMacros = self:GetChecked()
             updateButton()
         end)
         ignoreGeneralMacroCheckbox = b
@@ -165,8 +164,22 @@ do
         local b = CreateFrame("CheckButton", nil, f, "UICheckButtonTemplate")
         b.text = b:CreateFontString(nil, "OVERLAY", "GameFontNormal")
         b.text:SetPoint("LEFT", b, "RIGHT", 0, 1)
+        b:SetPoint("BOTTOMLEFT", 38, 45)
+        b.text:SetText(L["Ignore Character Macros"])
+        b:SetChecked(MyslotSettings.ignoreCharacterMacros)
+        b:SetScript("OnClick", function(self) 
+            MyslotSettings.ignoreCharacterMacros = self:GetChecked()
+            updateButton()
+        end)
+        ignoreCharacterMacroCheckbox = b
+    end
+
+    do
+        local b = CreateFrame("CheckButton", nil, f, "UICheckButtonTemplate")
+        b.text = b:CreateFontString(nil, "OVERLAY", "GameFontNormal")
+        b.text:SetPoint("LEFT", b, "RIGHT", 0, 1)
         b:SetPoint("BOTTOMLEFT", 340, 120)
-        b.text:SetText(L["Clear Action before applying"])
+        b.text:SetText(L["Clear Action bars before import"])
         b:SetChecked(MyslotSettings.clearAction)
         b:SetScript("OnClick", function(self) 
             MyslotSettings.clearAction = self:GetChecked()
@@ -179,7 +192,7 @@ do
         b.text = b:CreateFontString(nil, "OVERLAY", "GameFontNormal")
         b.text:SetPoint("LEFT", b, "RIGHT", 0, 1)
         b:SetPoint("BOTTOMLEFT", 340, 95)
-        b.text:SetText(L["Clear Binding before applying"])
+        b.text:SetText(L["Clear Keybinds before import"])
         b:SetChecked(MyslotSettings.clearBinding)
         b:SetScript("OnClick", function(self) 
             MyslotSettings.clearBinding = self:GetChecked()
@@ -192,12 +205,25 @@ do
         b.text = b:CreateFontString(nil, "OVERLAY", "GameFontNormal")
         b.text:SetPoint("LEFT", b, "RIGHT", 0, 1)
         b:SetPoint("BOTTOMLEFT", 340, 70)
-        b.text:SetText(L["Clear Macro before applying"])
-        b:SetChecked(MyslotSettings.clearMacro)
+        b.text:SetText(L["Clear General Macros before import"])
+        b:SetChecked(MyslotSettings.clearGeneralMacros)
         b:SetScript("OnClick", function(self) 
-            MyslotSettings.clearMacro = self:GetChecked()
+            MyslotSettings.clearGeneralMacros = self:GetChecked()
         end)
-        clearMacroCheckbox = b
+        clearGeneralMacroCheckbox = b
+    end
+
+    do
+        local b = CreateFrame("CheckButton", nil, f, "UICheckButtonTemplate")
+        b.text = b:CreateFontString(nil, "OVERLAY", "GameFontNormal")
+        b.text:SetPoint("LEFT", b, "RIGHT", 0, 1)
+        b:SetPoint("BOTTOMLEFT", 340, 45)
+        b.text:SetText(L["Clear Character Macros before import"])
+        b:SetChecked(MyslotSettings.clearCharacterMacros)
+        b:SetScript("OnClick", function(self) 
+            MyslotSettings.clearCharacterMacros = self:GetChecked()
+        end)
+        clearCharacterMacroCheckbox = b
     end
 
     -- Gather options
@@ -206,11 +232,12 @@ do
             return  {
                 ignoreAction = ignoreActionCheckbox:GetChecked(),
                 ignoreBinding = ignoreBindingCheckbox:GetChecked(),
-                ignoreMacro = ignoreMacroCheckbox:GetChecked(),
-                ignoreGeneralMacro = ignoreGeneralMacroCheckbox:GetChecked(),
+                ignoreGeneralMacros = ignoreGeneralMacroCheckbox:GetChecked(),
+                ignoreCharacterMacros = ignoreCharacterMacroCheckbox:GetChecked(),
                 clearAction = clearActionCheckbox:GetChecked(),
                 clearBinding = clearBindingCheckbox:GetChecked(),
-                clearMacro = clearMacroCheckbox:GetChecked(),
+                clearGeneralMacros = clearMacroCheckbox:GetChecked(),
+                clearCharacterMacros = clearCharacterMacroCheckbox:GetChecked(),
             }
         end
         gatherCheckboxOptions = f
@@ -266,7 +293,7 @@ RegEvent("ADDON_LOADED", function()
     do
         local t = CreateFrame("Frame", nil, f, BackdropTemplateMixin and "BackdropTemplate" or nil)
         t:SetWidth(600)
-        t:SetHeight(400)
+        t:SetHeight(275)
         t:SetPoint("TOPLEFT", f, 25, -75)
         t:SetBackdrop({ 
             bgFile = "Interface/Tooltips/UI-Tooltip-Background",
@@ -281,7 +308,7 @@ RegEvent("ADDON_LOADED", function()
     
         local s = CreateFrame("ScrollFrame", nil, t, "UIPanelScrollFrameTemplate")
         s:SetWidth(560)
-        s:SetHeight(375)
+        s:SetHeight(250)
         s:SetPoint("TOPLEFT", 10, -10)
 
 
@@ -512,19 +539,21 @@ RegEvent("ADDON_LOADED", function()
     -- Set Checkbox states
     MyslotSettings.ignoreAction = MyslotSettings.ignoreAction or false
     MyslotSettings.ignoreBinding = MyslotSettings.ignoreBinding or false
-    MyslotSettings.ignoreMacro = MyslotSettings.ignoreMacro or false
-    MyslotSettings.ignoreGeneralMacro = MyslotSettings.ignoreGeneralMacro or false
+    MyslotSettings.ignoreGeneralMacros = MyslotSettings.ignoreGeneralMacros or false
+    MyslotSettings.ignoreCharacterMacros = MyslotSettings.ignoreCharacterMacros or false
     MyslotSettings.clearAction = MyslotSettings.clearAction or false
     MyslotSettings.clearBinding = MyslotSettings.clearBinding or false
-    MyslotSettings.clearMacro = MyslotSettings.clearMacro or false
+    MyslotSettings.clearGeneralMacros = MyslotSettings.clearGeneralMacros or false
+    MyslotSettings.clearCharacterMacros = MyslotSettings.clearCharacterMacros or false
 
     ignoreActionCheckbox:SetChecked(MyslotSettings.ignoreAction)
     ignoreBindingCheckbox:SetChecked(MyslotSettings.ignoreBinding)
-    ignoreMacroCheckbox:SetChecked(MyslotSettings.ignoreMacro)
-    ignoreGeneralMacroCheckbox:SetChecked(MyslotSettings.ignoreGeneralMacro)
+    ignoreGeneralMacroCheckbox:SetChecked(MyslotSettings.ignoreGeneralMacros)
+    ignoreCharacterMacroCheckbox:SetChecked(MyslotSettings.ignoreCharacterMacros)
     clearActionCheckbox:SetChecked(MyslotSettings.clearAction)
     clearBindingCheckbox:SetChecked(MyslotSettings.clearBinding)
-    clearMacroCheckbox:SetChecked(MyslotSettings.clearMacro)
+    clearGeneralMacroCheckbox:SetChecked(MyslotSettings.clearGeneralMacros)
+    clearCharacterMacroCheckbox:SetChecked(MyslotSettings.clearCharacterMacros)
 
     icon:Register("Myslot", ldb:NewDataObject("Myslot", {
             icon = "Interface\\MacroFrame\\MacroFrame-Icon",

--- a/gui.lua
+++ b/gui.lua
@@ -7,7 +7,7 @@ local MAX_PROFILES_COUNT = 50
 
 local f = CreateFrame("Frame", nil, UIParent, BackdropTemplateMixin and "BackdropTemplate" or nil)
 f:SetWidth(650)
-f:SetHeight(625)
+f:SetHeight(515)
 f:SetBackdrop({
     bgFile = "Interface\\DialogFrame\\UI-DialogBox-Background",
     edgeFile = "Interface\\DialogFrame\\UI-DialogBox-Border",
@@ -84,11 +84,11 @@ local exportButton
 
 local ignoreActionCheckbox
 local ignoreBindingCheckbox
-local ignoreGeneralMacroCheckbox
+local ignoreAccountMacroCheckbox
 local ignoreCharacterMacroCheckbox
 local clearActionCheckbox
 local clearBindingCheckbox
-local clearGeneralMacroCheckbox
+local clearAccountMacroCheckbox
 local clearCharacterMacroCheckbox
 
 do
@@ -96,7 +96,7 @@ do
 
 
     local function updateButton()
-        local disable = ignoreActionCheckbox:GetChecked() and ignoreBindingCheckbox:GetChecked() and ignoreMacroCheckbox:GetChecked()
+        local disable = ignoreActionCheckbox:GetChecked() and ignoreBindingCheckbox:GetChecked() and ignoreAccountMacroCheckbox:GetChecked() and ignoreCharacterMacroCheckbox:GetChecked()
 
         if disable then
             importButton:Disable()
@@ -122,7 +122,7 @@ do
         local b = CreateFrame("CheckButton", nil, f, "UICheckButtonTemplate")
         b.text = b:CreateFontString(nil, "OVERLAY", "GameFontNormal")
         b.text:SetPoint("LEFT", b, "RIGHT", 0, 1)
-        b:SetPoint("BOTTOMLEFT", 38, 120)
+        b:SetPoint("BOTTOMLEFT", 38, 125)
         b.text:SetText(L["Ignore Action Bars"])
         b:SetChecked(MyslotSettings.ignoreAction)
         b:SetScript("OnClick", function(self) 
@@ -136,7 +136,7 @@ do
         local b = CreateFrame("CheckButton", nil, f, "UICheckButtonTemplate")
         b.text = b:CreateFontString(nil, "OVERLAY", "GameFontNormal")
         b.text:SetPoint("LEFT", b, "RIGHT", 0, 1)
-        b:SetPoint("BOTTOMLEFT", 38, 95)
+        b:SetPoint("BOTTOMLEFT", 38, 100)
         b.text:SetText(L["Ignore Key Bindings"])
         b:SetChecked(MyslotSettings.ignoreBinding)
         b:SetScript("OnClick", function(self) 
@@ -150,21 +150,21 @@ do
         local b = CreateFrame("CheckButton", nil, f, "UICheckButtonTemplate")
         b.text = b:CreateFontString(nil, "OVERLAY", "GameFontNormal")
         b.text:SetPoint("LEFT", b, "RIGHT", 0, 1)
-        b:SetPoint("BOTTOMLEFT", 38, 70)
-        b.text:SetText(L["Ignore General Macros"])
-        b:SetChecked(MyslotSettings.ignoreGeneralMacros)
+        b:SetPoint("BOTTOMLEFT", 38, 75)
+        b.text:SetText(L["Ignore Account Macros"])
+        b:SetChecked(MyslotSettings.ignoreAccountMacros)
         b:SetScript("OnClick", function(self) 
-            MyslotSettings.ignoreGeneralMacros = self:GetChecked()
+            MyslotSettings.ignoreAccountMacros = self:GetChecked()
             updateButton()
         end)
-        ignoreGeneralMacroCheckbox = b
+        ignoreAccountMacroCheckbox = b
     end
 
     do
         local b = CreateFrame("CheckButton", nil, f, "UICheckButtonTemplate")
         b.text = b:CreateFontString(nil, "OVERLAY", "GameFontNormal")
         b.text:SetPoint("LEFT", b, "RIGHT", 0, 1)
-        b:SetPoint("BOTTOMLEFT", 38, 45)
+        b:SetPoint("BOTTOMLEFT", 38, 50)
         b.text:SetText(L["Ignore Character Macros"])
         b:SetChecked(MyslotSettings.ignoreCharacterMacros)
         b:SetScript("OnClick", function(self) 
@@ -178,8 +178,8 @@ do
         local b = CreateFrame("CheckButton", nil, f, "UICheckButtonTemplate")
         b.text = b:CreateFontString(nil, "OVERLAY", "GameFontNormal")
         b.text:SetPoint("LEFT", b, "RIGHT", 0, 1)
-        b:SetPoint("BOTTOMLEFT", 340, 120)
-        b.text:SetText(L["Clear Action bars before import"])
+        b:SetPoint("BOTTOMLEFT", 340, 125)
+        b.text:SetText(L["Clear Action bars Before Import"])
         b:SetChecked(MyslotSettings.clearAction)
         b:SetScript("OnClick", function(self) 
             MyslotSettings.clearAction = self:GetChecked()
@@ -191,8 +191,8 @@ do
         local b = CreateFrame("CheckButton", nil, f, "UICheckButtonTemplate")
         b.text = b:CreateFontString(nil, "OVERLAY", "GameFontNormal")
         b.text:SetPoint("LEFT", b, "RIGHT", 0, 1)
-        b:SetPoint("BOTTOMLEFT", 340, 95)
-        b.text:SetText(L["Clear Keybinds before import"])
+        b:SetPoint("BOTTOMLEFT", 340, 100)
+        b.text:SetText(L["Clear Keybinds Before Import"])
         b:SetChecked(MyslotSettings.clearBinding)
         b:SetScript("OnClick", function(self) 
             MyslotSettings.clearBinding = self:GetChecked()
@@ -204,21 +204,21 @@ do
         local b = CreateFrame("CheckButton", nil, f, "UICheckButtonTemplate")
         b.text = b:CreateFontString(nil, "OVERLAY", "GameFontNormal")
         b.text:SetPoint("LEFT", b, "RIGHT", 0, 1)
-        b:SetPoint("BOTTOMLEFT", 340, 70)
-        b.text:SetText(L["Clear General Macros before import"])
-        b:SetChecked(MyslotSettings.clearGeneralMacros)
+        b:SetPoint("BOTTOMLEFT", 340, 75)
+        b.text:SetText(L["Clear Account Macros Before Import"])
+        b:SetChecked(MyslotSettings.clearAccountMacros)
         b:SetScript("OnClick", function(self) 
-            MyslotSettings.clearGeneralMacros = self:GetChecked()
+            MyslotSettings.clearAccountMacros = self:GetChecked()
         end)
-        clearGeneralMacroCheckbox = b
+        clearAccountMacroCheckbox = b
     end
 
     do
         local b = CreateFrame("CheckButton", nil, f, "UICheckButtonTemplate")
         b.text = b:CreateFontString(nil, "OVERLAY", "GameFontNormal")
         b.text:SetPoint("LEFT", b, "RIGHT", 0, 1)
-        b:SetPoint("BOTTOMLEFT", 340, 45)
-        b.text:SetText(L["Clear Character Macros before import"])
+        b:SetPoint("BOTTOMLEFT", 340, 50)
+        b.text:SetText(L["Clear Character Macros Before Import"])
         b:SetChecked(MyslotSettings.clearCharacterMacros)
         b:SetScript("OnClick", function(self) 
             MyslotSettings.clearCharacterMacros = self:GetChecked()
@@ -232,11 +232,11 @@ do
             return  {
                 ignoreAction = ignoreActionCheckbox:GetChecked(),
                 ignoreBinding = ignoreBindingCheckbox:GetChecked(),
-                ignoreGeneralMacros = ignoreGeneralMacroCheckbox:GetChecked(),
+                ignoreAccountMacros = ignoreAccountMacroCheckbox:GetChecked(),
                 ignoreCharacterMacros = ignoreCharacterMacroCheckbox:GetChecked(),
                 clearAction = clearActionCheckbox:GetChecked(),
                 clearBinding = clearBindingCheckbox:GetChecked(),
-                clearGeneralMacros = clearMacroCheckbox:GetChecked(),
+                clearAccountMacros = clearAccountMacroCheckbox:GetChecked(),
                 clearCharacterMacros = clearCharacterMacroCheckbox:GetChecked(),
             }
         end
@@ -539,20 +539,20 @@ RegEvent("ADDON_LOADED", function()
     -- Set Checkbox states
     MyslotSettings.ignoreAction = MyslotSettings.ignoreAction or false
     MyslotSettings.ignoreBinding = MyslotSettings.ignoreBinding or false
-    MyslotSettings.ignoreGeneralMacros = MyslotSettings.ignoreGeneralMacros or false
+    MyslotSettings.ignoreAccountMacros = MyslotSettings.ignoreAccountMacros or false
     MyslotSettings.ignoreCharacterMacros = MyslotSettings.ignoreCharacterMacros or false
     MyslotSettings.clearAction = MyslotSettings.clearAction or false
     MyslotSettings.clearBinding = MyslotSettings.clearBinding or false
-    MyslotSettings.clearGeneralMacros = MyslotSettings.clearGeneralMacros or false
+    MyslotSettings.clearAccountMacros = MyslotSettings.clearAccountMacros or false
     MyslotSettings.clearCharacterMacros = MyslotSettings.clearCharacterMacros or false
 
     ignoreActionCheckbox:SetChecked(MyslotSettings.ignoreAction)
     ignoreBindingCheckbox:SetChecked(MyslotSettings.ignoreBinding)
-    ignoreGeneralMacroCheckbox:SetChecked(MyslotSettings.ignoreGeneralMacros)
+    ignoreAccountMacroCheckbox:SetChecked(MyslotSettings.ignoreAccountMacros)
     ignoreCharacterMacroCheckbox:SetChecked(MyslotSettings.ignoreCharacterMacros)
     clearActionCheckbox:SetChecked(MyslotSettings.clearAction)
     clearBindingCheckbox:SetChecked(MyslotSettings.clearBinding)
-    clearGeneralMacroCheckbox:SetChecked(MyslotSettings.clearGeneralMacros)
+    clearAccountMacroCheckbox:SetChecked(MyslotSettings.clearAccountMacros)
     clearCharacterMacroCheckbox:SetChecked(MyslotSettings.clearCharacterMacros)
 
     icon:Register("Myslot", ldb:NewDataObject("Myslot", {
@@ -608,11 +608,12 @@ SlashCmdList["MYSLOT"] = function(msg, editbox)
             MySlot:RecoverData(msg, {
                 ignoreAction = false,
                 ignoreBinding = false,
-                ignoreMacro = false,
-                ignoreGeneralMacro = false,
+                ignoreAccountMacros = false,
+                ignoreCharacterMacros = false,
                 clearAction = false,
                 clearBinding = false,
-                clearMacro = false,
+                clearAccountMacros = false,
+                clearCharacterMacros = false,
             })
         end
 

--- a/options.lua
+++ b/options.lua
@@ -115,7 +115,7 @@ StaticPopupDialogs["MYSLOT_CONFIRM_CLEAR"] = {
         local tx = self.editBox:GetText()
 
         if tx == data then
-            MySlot:Clear(data)
+            MySlot:Clear(data, nil)
         else
             MySlot:Print(L["Please type %s to confirm"]:format(data))
         end


### PR DESCRIPTION
- Myslot now exports EVERYTHING always as this information can be useful for Action bars even if macros are being ignored on import
- Ignore options now support account vs character macros separately
- Ignore options ONLY apply to the import and do not prevent a CLEAR
- Added option to clear Account/Character macros seprarately
- Updated UI to be more UX friendly with a smaller text window and clear checkboxes for options
- Added some error handling on the Action Bar import where a macro could possibly not be found
- Checked options are now saved PER CHARACTER for easy reuse of the addon

![image](https://github.com/tg123/myslot/assets/14926986/d8fe056e-3bd8-4c8a-92f0-ceecac397224)

![image](https://github.com/tg123/myslot/assets/14926986/4dbbbd9d-c288-4b56-b0c7-ab8b6d4db8f4)

