### PR TITLE
add an option button and more options

### DIFF
--- a/gui.lua
+++ b/gui.lua
@@ -55,13 +55,25 @@ end
 
 local exportEditbox
 
+-- options
+do
+    local b = CreateFrame("Button", nil, f, "GameMenuButtonTemplate")
+    b:SetWidth(100)
+    b:SetHeight(25)
+    b:SetPoint("BOTTOMRIGHT", -145, 15)
+    b:SetText(OPTIONS)
+    b:SetScript("OnClick", function()
+        Settings.OpenToCategory(MySlot.settingcategory.ID)
+    end)
+end
+
 -- close
 do
     local b = CreateFrame("Button", nil, f, "GameMenuButtonTemplate")
     b:SetWidth(100)
     b:SetHeight(25)
     b:SetPoint("BOTTOMRIGHT", -40, 15)
-    b:SetText(L["Close"])
+    b:SetText(CLOSE)
     b:SetScript("OnClick", function() f:Hide() end)
 end
 
@@ -396,6 +408,15 @@ do
 
             MySlot:Print(L["Starting backup..."])
             local backup = MySlot:Export(actionOpt)
+
+            if not backup then
+                MySlot:Print(L["Backup failed"])
+
+                if not forceImport then
+                    return
+                end
+            end
+
             table.insert(MyslotExports["backups"], backup)
             while #MyslotExports["backups"] > IMPORT_BACKUP_COUNT do
                 table.remove(MyslotExports["backups"], 1)

--- a/gui.lua
+++ b/gui.lua
@@ -458,6 +458,7 @@ do
 
     tAppendAll(settings, CreateSettingMenu(actionOpt))
 
+    local clearbegin = #settings + 1
     tAppendAll(settings, {
         {
             isTitle = true,
@@ -468,6 +469,7 @@ do
     tAppendAll(settings, CreateSettingMenu(clearOpt))
 
     table.remove(settings) -- remove pet action bar clearOpt, will support it later
+    local clearend = #settings
 
     tAppendAll(settings, {
         {
@@ -488,8 +490,15 @@ do
         }
     })
 
+    local settingswithoutclear = {}
+    tAppendAll(settingswithoutclear, settings)
+    for i = clearend, clearbegin, -1 do
+        table.remove(settingswithoutclear, i)
+    end
+
+
     ba:SetScript("OnClick", function(self, button)
-        EasyMenu(settings, menuFrame, "cursor", 0 , 0, "MENU");
+        EasyMenu(MyslotSettings.allowclearonimport and settings or settingswithoutclear, menuFrame, "cursor", 0 , 0, "MENU");
     end)
 end
 

--- a/options.lua
+++ b/options.lua
@@ -35,9 +35,9 @@ RegEvent("ADDON_LOADED", function()
         end)
     end
 
+    MyslotSettings = MyslotSettings or {}
 
     do
-        MyslotSettings = MyslotSettings or {}
         MyslotSettings.minimap = MyslotSettings.minimap or { hide = false }
         local config = MyslotSettings.minimap
 
@@ -97,6 +97,19 @@ RegEvent("ADDON_LOADED", function()
         b:SetText(L["Remove all Macros"])
         b:SetScript("OnClick", function()
             StaticPopup_Show("MYSLOT_CONFIRM_CLEAR", "MACRO", nil, "MACRO")
+        end)
+    end
+
+    do
+        local b = CreateFrame("CheckButton", nil, f, "UICheckButtonTemplate")
+        b:SetPoint("TOPLEFT", f, 15, doffset - 110)
+
+        b.text = b:CreateFontString(nil, "OVERLAY", "GameFontNormal")
+        b.text:SetPoint("LEFT", b, "RIGHT", 0, 1)
+        b.text:SetText(L["Allow"] .. " " .. "|cffff0000" .. L["CLEAR"] .. "|r" .. " " .. L[" before Import"])
+        b:SetChecked(MyslotSettings.allowclearonimport)
+        b:SetScript("OnClick", function()
+            MyslotSettings.allowclearonimport = b:GetChecked()
         end)
     end
 end)


### PR DESCRIPTION
clear before import is now disabled by default because too many complains about player accidently clear their settings.