### PR TITLE
fix: script name reference in documentation

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -70,7 +70,7 @@ $ git clone https://github.com/tg123/myslot.git Myslot
  * pull the localizations from wowace (optional)
 
 ```
-./update_locale.sh
+./extract_locale.sh
 ```
  
 #### Changing Protobuf


### PR DESCRIPTION
This pull request fixes the script name reference in documentation build section from './update_locale.sh' to './extract_locale.sh'.