### PR TITLE
Update TOC file to reflect correct interface versions

### DIFF
--- a/Myslot.toc
+++ b/Myslot.toc
@@ -1,4 +1,4 @@
-## Interface: 120005, 110207
+## Interface: 120100, 120007, 110207
 ## Interface-Classic: 11508
 ## Interface-BCC: 20505
 ## Interface-Wrath: 30405


### PR DESCRIPTION
Updates `Myslot.toc` interface versions: replaces `120005` with `120100, 120007` for Midnight 12.1 compatibility (keeps `110207`).