### PR TITLE
Add support for outfit slot type

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -45,6 +45,7 @@ read_globals = {
     "C_Spell",
     "C_SpellBook",
     "C_Timer",
+    "C_TransmogOutfitInfo",
     "C_UI",
     "ClearCursor",
     "CreateFrame",

--- a/Myslot.lua
+++ b/Myslot.lua
@@ -953,12 +953,13 @@ function MySlot:RecoverData(msg, opt)
                     elseif slotType == MYSLOT_EQUIPMENTSET then
                         C_EquipmentSet.PickupEquipmentSet(index)
                     elseif slotType == MYSLOT_OUTFIT then
-                        if C_TransmogOutfitInfo then
+                        if C_TransmogOutfitInfo and C_TransmogOutfitInfo.PickupOutfit then
                             C_TransmogOutfitInfo.PickupOutfit(index)
 
                             -- id may not exist on this character/account; fall
                             -- back to matching the saved outfit by name.
-                            if not GetCursorInfo() and strindex and strindex ~= "" then
+                            if not GetCursorInfo() and strindex and strindex ~= ""
+                                and C_TransmogOutfitInfo.GetOutfitInfoByName then
                                 local outfitInfo = C_TransmogOutfitInfo.GetOutfitInfoByName(strindex)
                                 if outfitInfo then
                                     C_TransmogOutfitInfo.PickupOutfit(outfitInfo.outfitID)
@@ -966,7 +967,7 @@ function MySlot:RecoverData(msg, opt)
                             end
 
                             if not GetCursorInfo() then
-                                MySlot:Print(L["Ignore unknown outfit [id=%s]"]:format(strindex or index))
+                                MySlot:Print(L["Ignore unknown outfit [id=%s, name=%s]"]:format(index, strindex or ""))
                             end
                         end
                     end

--- a/Myslot.lua
+++ b/Myslot.lua
@@ -39,6 +39,7 @@ local MYSLOT_EQUIPMENTSET = _MySlot.Slot.SlotType.EQUIPMENTSET
 local MYSLOT_EMPTY = _MySlot.Slot.SlotType.EMPTY
 local MYSLOT_SUMMONPET = _MySlot.Slot.SlotType.SUMMONPET
 local MYSLOT_SUMMONMOUNT = _MySlot.Slot.SlotType.SUMMONMOUNT
+local MYSLOT_OUTFIT = _MySlot.Slot.SlotType.OUTFIT
 local MYSLOT_NOTFOUND = "notfound"
 
 MySlot.SLOT_TYPE = {
@@ -52,6 +53,7 @@ MySlot.SLOT_TYPE = {
     ["equipmentset"] = MYSLOT_EQUIPMENTSET,
     ["summonpet"] = MYSLOT_SUMMONPET,
     ["summonmount"] = MYSLOT_SUMMONMOUNT,
+    ["outfit"] = MYSLOT_OUTFIT,
     [MYSLOT_NOTFOUND] = MYSLOT_EMPTY,
 }
 -- }}}
@@ -260,12 +262,23 @@ end
 -- {{{ GetActionInfo
 function MySlot:GetActionInfo(slotId)
     local slotType, index, subType = GetActionInfo(slotId)
+    local strindexOverride = nil
     if MySlot.SLOT_TYPE[slotType] == MYSLOT_EQUIPMENTSET then
         -- i starts from 0 https://github.com/tg123/myslot/issues/10 weird blz
         for i = 0, C_EquipmentSet.GetNumEquipmentSets() do
             if C_EquipmentSet.GetEquipmentSetInfo(i) == index then
                 index = i
                 break
+            end
+        end
+    elseif MySlot.SLOT_TYPE[slotType] == MYSLOT_OUTFIT then
+        -- `index` is the account-wide outfitID. Also record the outfit name so
+        -- Import can fall back to matching by name when the id doesn't exist
+        -- (e.g. importing someone else's export). https://github.com/tg123/myslot/issues/110
+        if C_TransmogOutfitInfo and C_TransmogOutfitInfo.GetOutfitInfo then
+            local outfitInfo = C_TransmogOutfitInfo.GetOutfitInfo(index)
+            if outfitInfo then
+                strindexOverride = outfitInfo.name
             end
         end
     elseif not MySlot.SLOT_TYPE[slotType] then
@@ -291,6 +304,9 @@ function MySlot:GetActionInfo(slotId)
         msg.index = 0
     else
         msg.index = index
+    end
+    if strindexOverride then
+        msg.strindex = strindexOverride
     end
     return msg
 end
@@ -936,6 +952,23 @@ function MySlot:RecoverData(msg, opt)
                         PickupAction(slotId)
                     elseif slotType == MYSLOT_EQUIPMENTSET then
                         C_EquipmentSet.PickupEquipmentSet(index)
+                    elseif slotType == MYSLOT_OUTFIT then
+                        if C_TransmogOutfitInfo then
+                            C_TransmogOutfitInfo.PickupOutfit(index)
+
+                            -- id may not exist on this character/account; fall
+                            -- back to matching the saved outfit by name.
+                            if not GetCursorInfo() and strindex and strindex ~= "" then
+                                local outfitInfo = C_TransmogOutfitInfo.GetOutfitInfoByName(strindex)
+                                if outfitInfo then
+                                    C_TransmogOutfitInfo.PickupOutfit(outfitInfo.outfitID)
+                                end
+                            end
+
+                            if not GetCursorInfo() then
+                                MySlot:Print(L["Ignore unknown outfit [id=%s]"]:format(strindex or index))
+                            end
+                        end
                     end
 
                     if GetCursorInfo() then

--- a/protobuf/MySlot.proto
+++ b/protobuf/MySlot.proto
@@ -25,6 +25,7 @@ message Slot {
 		SUMMONPET = 7;
 		COMPANION = 8;
 		SUMMONMOUNT = 9;
+		OUTFIT = 10;
 	}
 
 	required SlotType type = 2;

--- a/protobuf/Myslot.lua
+++ b/protobuf/Myslot.lua
@@ -297,6 +297,7 @@ local t = {
    "SUMMONPET",
    "COMPANION",
    "SUMMONMOUNT",
+   "OUTFIT",
    ["EMPTY"]=5,
    ["FLYOUT"]=4,
    ["SPELL"]=1,
@@ -306,6 +307,7 @@ local t = {
    ["MACRO"]=3,
    ["COMPANION"]=8,
    ["EQUIPMENTSET"]=6,
+   ["OUTFIT"]=10,
 },
 }
    local function loadast()

--- a/tests/cases/protobuf.lua
+++ b/tests/cases/protobuf.lua
@@ -48,4 +48,17 @@ T.describe("protobuf Charactor message", function()
         T.assert.equal(7, out.id)
         T.assert.equal("ASSISTEDCOMBAT", out.strindex)
     end)
+
+    T.it("round-trips an outfit slot (id + name)", function()
+        local s = _MySlot.Slot()
+        s.id = 42
+        s.type = _MySlot.Slot.SlotType.OUTFIT
+        s.index = 1234
+        s.strindex = "My Cool Outfit"
+        local out = _MySlot.Slot():Parse(s:Serialize())
+        T.assert.equal(42, out.id)
+        T.assert.equal(1234, out.index)
+        T.assert.equal("My Cool Outfit", out.strindex)
+        T.assert.equal(_MySlot.Slot.SlotType.OUTFIT, _MySlot.Slot.SlotType[out.type])
+    end)
 end)

--- a/tests/cases/wow_roundtrip.lua
+++ b/tests/cases/wow_roundtrip.lua
@@ -378,7 +378,7 @@ T.describe("in-game: slot type round-trip (per type)", function()
     end))
 
     T.it("type=outfit", in_game(function()
-        if not (C_TransmogOutfitInfo and C_TransmogOutfitInfo.GetOutfitsInfo) then
+        if not (C_TransmogOutfitInfo and C_TransmogOutfitInfo.GetOutfitsInfo and C_TransmogOutfitInfo.PickupOutfit) then
             T.skip("no transmog outfit API")
         end
         local outfits = C_TransmogOutfitInfo.GetOutfitsInfo()

--- a/tests/cases/wow_roundtrip.lua
+++ b/tests/cases/wow_roundtrip.lua
@@ -377,6 +377,21 @@ T.describe("in-game: slot type round-trip (per type)", function()
         end)
     end))
 
+    T.it("type=outfit", in_game(function()
+        if not (C_TransmogOutfitInfo and C_TransmogOutfitInfo.GetOutfitsInfo) then
+            T.skip("no transmog outfit API")
+        end
+        local outfits = C_TransmogOutfitInfo.GetOutfitsInfo()
+        if not outfits or #outfits == 0 then T.skip("no saved outfits") end
+        local outfitID = outfits[1].outfitID
+        roundtrip(function(s)
+            ClearCursor()
+            C_TransmogOutfitInfo.PickupOutfit(outfitID)
+            PlaceAction(s)
+            ClearCursor()
+        end)
+    end))
+
     T.it("type=flyout", in_game(function()
         local flyoutID
         for tab = 1, (GetNumSpellTabs and GetNumSpellTabs() or 0) do


### PR DESCRIPTION
Adds export/import support for the new WoW 12.0 transmog **outfit** action type, fixing the `Unsupported Slot Type [outfit]` error.

## Changes
- **protobuf**: add `OUTFIT = 10` to `Slot.SlotType` (proto + regenerated stub).
- **Export** (`GetActionInfo`): store `index = outfitID` and `strindex = outfit name` so imports can recover by name when the id isn't on the target account.
- **Import** (`RecoverData`): `C_TransmogOutfitInfo.PickupOutfit(index)`, falling back to `GetOutfitInfoByName(strindex)` if the id is unknown; warns if still unresolved. Guarded by `if C_TransmogOutfitInfo`.
- **Tests**: protobuf round-trip (id + name) and an in-game `type=outfit` round-trip (skips in CI without the API / a saved outfit).
- **.luacheckrc**: whitelist `C_TransmogOutfitInfo`.

CI: 19 passed / 0 failed / 15 skipped; luacheck clean.

Closes #110