### PR TITLE
Hide unsupported export options cross-version

### DIFF
--- a/Myslot.lua
+++ b/Myslot.lua
@@ -933,11 +933,23 @@ local PET_CAPABLE_CLASSES = {
     HUNTER = true,
     WARLOCK = true,
     DEATHKNIGHT = true,
-    MAGE = true,
 }
+-- Mages only gain a controllable pet (Water Elemental) with its own pet action
+-- bar on WotLK and later; on Vanilla/TBC-era clients a mage never has a pet
+-- action bar, so gate them on the client's interface version.
+local MAGE_PET_MIN_INTERFACE = 30000
 function MySlot:IsPetActionBarSupported()
     local _, class = UnitClass("player")
-    return class ~= nil and PET_CAPABLE_CLASSES[class] or false
+    if class == nil then
+        return false
+    end
+    if PET_CAPABLE_CLASSES[class] then
+        return true
+    end
+    if class == "MAGE" then
+        return (select(4, GetBuildInfo()) or 0) >= MAGE_PET_MIN_INTERFACE
+    end
+    return false
 end
 
 function MySlot:RecoverData(msg, opt)

--- a/Myslot.lua
+++ b/Myslot.lua
@@ -512,7 +512,7 @@ function MySlot:Export(opt)
         end
     end
 
-    if not opt.ignoreCooldownManager and C_CooldownViewer and C_CooldownViewer.GetLayoutData then
+    if not opt.ignoreCooldownManager and self:IsCooldownManagerSupported() then
         local layout = C_CooldownViewer.GetLayoutData()
         if layout and layout ~= "" then
             msg.cooldownManager = layout
@@ -520,7 +520,7 @@ function MySlot:Export(opt)
     end
 
     msg.clickBinding = {}
-    if not opt.ignoreClickBindings and C_ClickBindings and C_ClickBindings.GetProfileInfo then
+    if not opt.ignoreClickBindings and self:IsClickBindingSupported() then
         for _, info in ipairs(C_ClickBindings.GetProfileInfo()) do
             local c = _MySlot.ClickBinding()
             c.type = info.type
@@ -894,6 +894,52 @@ local function MoveAllCooldownsToNotDisplayed()
     return true
 end
 
+-- Cooldown Manager (Cooldown Viewer) is retail-only in practice. Its
+-- Blizzard_CooldownViewer addon carries "## AllowLoadGameType: standard", so it
+-- only loads on retail. The C_CooldownViewer C-namespace (incl. GetLayoutData,
+-- SetLayoutData and even IsCooldownViewerAvailable) is ALSO present on Classic
+-- clients where that addon never loads, so neither a namespace check nor
+-- IsCooldownViewerAvailable() can tell the two apart. Detect the addon actually
+-- being loaded (which also guarantees CooldownViewerSettings, used by import).
+local IsAddOnLoaded = (C_AddOns and C_AddOns.IsAddOnLoaded) or _G.IsAddOnLoaded
+function MySlot:IsCooldownManagerSupported()
+    return IsAddOnLoaded
+        and IsAddOnLoaded("Blizzard_CooldownViewer")
+        and C_CooldownViewer
+        and C_CooldownViewer.GetLayoutData
+        and C_CooldownViewer.SetLayoutData
+        and true
+        or false
+end
+
+-- Click Cast Bindings (C_ClickBindings) are retail-only. Unlike C_CooldownViewer,
+-- the namespace is genuinely ABSENT on Classic (Blizzard's own SecureTemplates
+-- notes "If Classic has ClickBindings someday, remove this"), so a namespace
+-- check is sufficient and correct here.
+function MySlot:IsClickBindingSupported()
+    return C_ClickBindings
+        and C_ClickBindings.GetProfileInfo
+        and C_ClickBindings.SetProfileByInfo
+        and true
+        or false
+end
+
+-- The pet action bar exists on every client, but only some classes can ever
+-- control a pet (and thus have a pet action bar). The player's class is fixed
+-- for the session, so this is a stable signal for hiding the pet option for
+-- classes that can never have a pet (unlike HasPetUI, which tracks whether a
+-- pet is currently out).
+local PET_CAPABLE_CLASSES = {
+    HUNTER = true,
+    WARLOCK = true,
+    DEATHKNIGHT = true,
+    MAGE = true,
+}
+function MySlot:IsPetActionBarSupported()
+    local _, class = UnitClass("player")
+    return class ~= nil and PET_CAPABLE_CLASSES[class] or false
+end
+
 function MySlot:RecoverData(msg, opt)
     -- {{{ Cache Spells
     --cache spells
@@ -1217,13 +1263,13 @@ function MySlot:RecoverData(msg, opt)
 
 
     if not opt.actionOpt.ignoreCooldownManager and msg.cooldownManager and msg.cooldownManager ~= ""
-        and C_CooldownViewer and C_CooldownViewer.SetLayoutData then
+        and self:IsCooldownManagerSupported() then
         ApplyCooldownLayout(msg.cooldownManager)
     end
 
 
     if not opt.actionOpt.ignoreClickBindings and not IsEmptyTable(msg.clickBinding)
-        and C_ClickBindings and C_ClickBindings.SetProfileByInfo then
+        and self:IsClickBindingSupported() then
         -- Enum.ClickBindingType.Macro; macros are referenced by index, which the
         -- macro restore above may have relocated, so remap through macroIdMap.
         local MACRO_TYPE = (Enum and Enum.ClickBindingType and Enum.ClickBindingType.Macro) or 2
@@ -1288,13 +1334,15 @@ function MySlot:Clear(what, opt)
         end
         SaveBindings(GetCurrentBindingSet())
     elseif what == "COOLDOWNMANAGER" then
-        MoveAllCooldownsToNotDisplayed()
+        if self:IsCooldownManagerSupported() then
+            MoveAllCooldownsToNotDisplayed()
+        end
     elseif what == "CLICKBINDING" then
         -- Remove all click bindings by committing an empty profile.
         -- (ResetCurrentProfile reverts to the Blizzard default, which isn't "remove
         -- all"; SetProfileByInfo is the real save/commit API.)
         -- SetProfileByInfo is protected in combat, so skip while in combat lockdown.
-        if C_ClickBindings and C_ClickBindings.SetProfileByInfo and not InCombatLockdown() then
+        if self:IsClickBindingSupported() and not InCombatLockdown() then
             C_ClickBindings.SetProfileByInfo({})
         end
     end

--- a/ci/wow_stubs.lua
+++ b/ci/wow_stubs.lua
@@ -43,6 +43,7 @@ function Stub.reset()
     }
     Stub.cooldown_moves = {}     -- [cooldownID] = category the cooldown was moved to
     Stub.cooldown_saved = false  -- set when SaveCurrentLayout runs
+    Stub.cooldown_addon_loaded = true  -- Blizzard_CooldownViewer loaded? (retail=true)
     Stub.click_bindings = {}     -- vector of ClickBindingInfo {type, actionID, button, modifiers}
 end
 
@@ -112,6 +113,18 @@ C_CooldownViewer = {
         return Stub.cooldown_category_set[category] or {}
     end,
 }
+
+-- C_AddOns.IsAddOnLoaded gates Cooldown Manager support: Blizzard_CooldownViewer
+-- only loads on retail ("## AllowLoadGameType: standard"), while the
+-- C_CooldownViewer C-namespace is present on Classic too. Tests can flip
+-- Stub.cooldown_addon_loaded = false to simulate a Classic client.
+C_AddOns = C_AddOns or {}
+C_AddOns.IsAddOnLoaded = C_AddOns.IsAddOnLoaded or function(name)
+    if name == "Blizzard_CooldownViewer" then
+        return Stub.cooldown_addon_loaded ~= false
+    end
+    return true
+end
 
 -- Pseudo-categories used by the settings UI to represent "Not Displayed".
 Enum = Enum or {}

--- a/ci/wow_stubs.lua
+++ b/ci/wow_stubs.lua
@@ -45,6 +45,7 @@ function Stub.reset()
     Stub.cooldown_saved = false  -- set when SaveCurrentLayout runs
     Stub.cooldown_addon_loaded = true  -- Blizzard_CooldownViewer loaded? (retail=true)
     Stub.click_bindings = {}     -- vector of ClickBindingInfo {type, actionID, button, modifiers}
+    Stub.interface_version = 110000  -- 4th GetBuildInfo() return (retail Mainline)
 end
 
 Stub.reset()
@@ -53,7 +54,7 @@ Stub.reset()
 function IsWindowsClient() return Stub.is_windows end
 function IsWindowsServer() return Stub.is_windows end
 function GetLocale() return Stub.locale end
-function GetBuildInfo() return "11.0.0", "00000", "2024-01-01", 110000 end
+function GetBuildInfo() return "11.0.0", "00000", "2024-01-01", Stub.interface_version end
 function InCombatLockdown() return Stub.in_combat end
 
 -- --- Chat / UI -------------------------------------------------------------

--- a/gui.lua
+++ b/gui.lua
@@ -347,7 +347,7 @@ local function CreateSettingMenu(opt, onChanged)
         -- end
     end
 
-    return {
+    local menu = {
         {
             text = ACTIONBARS_LABEL,
             hasArrow = true,
@@ -454,6 +454,27 @@ local function CreateSettingMenu(opt, onChanged)
             end,
         }, -- 6
     }
+
+    -- Some categories are retail-only; drop their entries where the client
+    -- doesn't support them (e.g. Classic) so we never offer an option that
+    -- can't apply.
+    local unsupported = {}
+    if not MySlot:IsCooldownManagerSupported() then
+        unsupported[L["Cooldown Manager"]] = true
+    end
+    if not MySlot:IsClickBindingSupported() then
+        unsupported[L["Click Cast Bindings"]] = true
+    end
+    if not MySlot:IsPetActionBarSupported() then
+        unsupported[PET .. " " .. ACTIONBARS_LABEL] = true
+    end
+    for i = #menu, 1, -1 do
+        if menu[i].text and unsupported[menu[i].text] then
+            table.remove(menu, i)
+        end
+    end
+
+    return menu
 end
 
 local function AllSettingMenuIgnored(opt)
@@ -483,15 +504,15 @@ local function AllSettingMenuIgnored(opt)
         end
     end
 
-    if not opt.ignorePetActionBar then
+    if MySlot:IsPetActionBarSupported() and not opt.ignorePetActionBar then
         return false
     end
 
-    if not opt.ignoreCooldownManager then
+    if MySlot:IsCooldownManagerSupported() and not opt.ignoreCooldownManager then
         return false
     end
 
-    if not opt.ignoreClickBindings then
+    if MySlot:IsClickBindingSupported() and not opt.ignoreClickBindings then
         return false
     end
 
@@ -641,20 +662,23 @@ do
     end
     tAppendAll(settings, clearMenu)
 
-    tAppendAll(settings, {
-        {
-            text = L["Cooldown Manager"],
-            notCheckable = false,
-            isNotRadio = true,
-            keepShownOnClick = true,
-            func = function ()
-                clearOpt.removeCooldownManager = not clearOpt.removeCooldownManager
-            end,
-            checked = function ()
-                return clearOpt.removeCooldownManager
-            end,
-        },
-    })
+    -- Cooldown Manager "remove all" only makes sense on clients that have it.
+    if MySlot:IsCooldownManagerSupported() then
+        tAppendAll(settings, {
+            {
+                text = L["Cooldown Manager"],
+                notCheckable = false,
+                isNotRadio = true,
+                keepShownOnClick = true,
+                func = function ()
+                    clearOpt.removeCooldownManager = not clearOpt.removeCooldownManager
+                end,
+                checked = function ()
+                    return clearOpt.removeCooldownManager
+                end,
+            },
+        })
+    end
 
     local clearend = #settings
 

--- a/options.lua
+++ b/options.lua
@@ -98,7 +98,7 @@ RegEvent("ADDON_LOADED", function()
 
     do
         local b = CreateFrame("CheckButton", nil, f, "UICheckButtonTemplate")
-        b:SetPoint("TOPLEFT", f, 15, rowy - 30)
+        b:SetPoint("TOPLEFT", f, 15, rowy)
 
         b.text = b:CreateFontString(nil, "OVERLAY", "GameFontNormal")
         b.text:SetPoint("LEFT", b, "RIGHT", 0, 1)

--- a/options.lua
+++ b/options.lua
@@ -67,64 +67,38 @@ RegEvent("ADDON_LOADED", function()
         t:SetPoint("TOPLEFT", f, 15, doffset)
     end
 
-    do
+    -- Running vertical cursor so hidden rows (e.g. Cooldown Manager on Classic)
+    -- don't leave a gap; each row advances the offset by 30px.
+    local rowy = doffset - 20
+    local function AddClearButton(text, what)
         local b = CreateFrame("Button", nil, f, "GameMenuButtonTemplate")
         b:SetWidth(240)
         b:SetHeight(25)
-        b:SetPoint("TOPLEFT", 15, doffset - 20)
-        b:SetText(L["Remove everything in ActionBar"])
+        b:SetPoint("TOPLEFT", 15, rowy)
+        b:SetText(text)
         b:SetScript("OnClick", function()
-            StaticPopup_Show("MYSLOT_CONFIRM_CLEAR", "ACTION", nil, "ACTION")
+            StaticPopup_Show("MYSLOT_CONFIRM_CLEAR", what, nil, what)
         end)
+        rowy = rowy - 30
     end
 
-    do
-        local b = CreateFrame("Button", nil, f, "GameMenuButtonTemplate")
-        b:SetWidth(240)
-        b:SetHeight(25)
-        b:SetPoint("TOPLEFT", 15, doffset - 50)
-        b:SetText(L["Remove all Key Bindings"])
-        b:SetScript("OnClick", function()
-            StaticPopup_Show("MYSLOT_CONFIRM_CLEAR", "BINDING", nil, "BINDING")
-        end)
+    AddClearButton(L["Remove everything in ActionBar"], "ACTION")
+    AddClearButton(L["Remove all Key Bindings"], "BINDING")
+    AddClearButton(L["Remove all Macros"], "MACRO")
+
+    -- Cooldown Manager is retail-only; only offer it where supported.
+    if MySlot:IsCooldownManagerSupported() then
+        AddClearButton(L["Remove all Cooldown Manager"], "COOLDOWNMANAGER")
     end
 
-    do
-        local b = CreateFrame("Button", nil, f, "GameMenuButtonTemplate")
-        b:SetWidth(240)
-        b:SetHeight(25)
-        b:SetPoint("TOPLEFT", 15, doffset - 80)
-        b:SetText(L["Remove all Macros"])
-        b:SetScript("OnClick", function()
-            StaticPopup_Show("MYSLOT_CONFIRM_CLEAR", "MACRO", nil, "MACRO")
-        end)
-    end
-
-    do
-        local b = CreateFrame("Button", nil, f, "GameMenuButtonTemplate")
-        b:SetWidth(240)
-        b:SetHeight(25)
-        b:SetPoint("TOPLEFT", 15, doffset - 110)
-        b:SetText(L["Remove all Cooldown Manager"])
-        b:SetScript("OnClick", function()
-            StaticPopup_Show("MYSLOT_CONFIRM_CLEAR", "COOLDOWNMANAGER", nil, "COOLDOWNMANAGER")
-        end)
-    end
-
-    do
-        local b = CreateFrame("Button", nil, f, "GameMenuButtonTemplate")
-        b:SetWidth(240)
-        b:SetHeight(25)
-        b:SetPoint("TOPLEFT", 15, doffset - 140)
-        b:SetText(L["Remove all Click Cast Bindings"])
-        b:SetScript("OnClick", function()
-            StaticPopup_Show("MYSLOT_CONFIRM_CLEAR", "CLICKBINDING", nil, "CLICKBINDING")
-        end)
+    -- Click Cast Bindings are retail-only; only offer it where supported.
+    if MySlot:IsClickBindingSupported() then
+        AddClearButton(L["Remove all Click Cast Bindings"], "CLICKBINDING")
     end
 
     do
         local b = CreateFrame("CheckButton", nil, f, "UICheckButtonTemplate")
-        b:SetPoint("TOPLEFT", f, 15, doffset - 170)
+        b:SetPoint("TOPLEFT", f, 15, rowy - 30)
 
         b.text = b:CreateFontString(nil, "OVERLAY", "GameFontNormal")
         b.text:SetPoint("LEFT", b, "RIGHT", 0, 1)

--- a/tests/cases/roundtrip.lua
+++ b/tests/cases/roundtrip.lua
@@ -147,6 +147,16 @@ T.describe("Export/Import round-trip", function()
         _G.WowStub.player.class = "ROGUE"
         T.assert.equal(false, MySlot:IsPetActionBarSupported())
 
+        -- Mages only have a controllable pet bar on WotLK+ (interface >= 30000);
+        -- on Vanilla/TBC-era clients the pet option stays hidden for them.
+        local saved_iface = _G.WowStub.interface_version
+        _G.WowStub.player.class = "MAGE"
+        _G.WowStub.interface_version = 110000
+        T.assert.equal(true, MySlot:IsPetActionBarSupported())
+        _G.WowStub.interface_version = 11507
+        T.assert.equal(false, MySlot:IsPetActionBarSupported())
+        _G.WowStub.interface_version = saved_iface
+
         _G.WowStub.player.class = saved
     end)
 

--- a/tests/cases/roundtrip.lua
+++ b/tests/cases/roundtrip.lua
@@ -110,6 +110,46 @@ T.describe("Export/Import round-trip", function()
         T.assert.equal(nil, msg)
     end)
 
+    T.it("reports cooldown manager support based on the loaded addon", function()
+        if Host.in_wow then T.skip("CI-only (stub-backed)") end
+
+        -- Stub-backed CI env has Blizzard_CooldownViewer loaded -> supported.
+        T.assert.equal(true, MySlot:IsCooldownManagerSupported())
+
+        -- Classic clients ship the C_CooldownViewer namespace but never load the
+        -- Blizzard_CooldownViewer addon, so support must be false there.
+        _G.WowStub.cooldown_addon_loaded = false
+        T.assert.equal(false, MySlot:IsCooldownManagerSupported())
+        _G.WowStub.cooldown_addon_loaded = true
+    end)
+
+    T.it("reports click binding support based on C_ClickBindings", function()
+        if Host.in_wow then T.skip("CI-only (stub-backed)") end
+
+        T.assert.equal(true, MySlot:IsClickBindingSupported())
+
+        -- The C_ClickBindings namespace is genuinely absent on Classic.
+        local saved = _G.C_ClickBindings
+        _G.C_ClickBindings = nil
+        T.assert.equal(false, MySlot:IsClickBindingSupported())
+        _G.C_ClickBindings = saved
+    end)
+
+    T.it("reports pet action bar support based on the player's class", function()
+        if Host.in_wow then T.skip("CI-only (stub-backed)") end
+
+        local saved = _G.WowStub.player.class
+
+        _G.WowStub.player.class = "HUNTER"
+        T.assert.equal(true, MySlot:IsPetActionBarSupported())
+
+        -- A class that can never have a pet hides the pet action bar option.
+        _G.WowStub.player.class = "ROGUE"
+        T.assert.equal(false, MySlot:IsPetActionBarSupported())
+
+        _G.WowStub.player.class = saved
+    end)
+
     T.it("export captures the cooldown manager layout blob", function()
         -- Drives the C_CooldownViewer stub: Export should pull GetLayoutData()
         -- into msg.cooldownManager. The SetLayoutData import wiring is covered by

--- a/tests/cases/wow_roundtrip.lua
+++ b/tests/cases/wow_roundtrip.lua
@@ -146,7 +146,13 @@ local function create_test_macro(name, icon, body)
     -- yield once to let it become queryable by name/body before we (or
     -- RecoverData's macro index) look it up. No-op in CI (sync mode).
     T.yield()
-    return id
+    -- Trust the live macro list for the authoritative index: CreateMacro's return
+    -- value is NOT the macro index on Classic Era, so deleting/placing by it would
+    -- target the wrong macro. find_macro_by_name gives the real index on every
+    -- client (and equals CreateMacro's return on retail).
+    local index = find_macro_by_name(name)
+    T.assert.not_nil(index, "macro '" .. name .. "' not queryable after create")
+    return index
 end
 
 -- ---------------------------------------------------------------------------
@@ -478,8 +484,8 @@ end)
 T.describe("in-game: cooldown manager round-trip (via WoW API)", function()
 
     T.it("restores the cooldown manager layout and refreshes the live state", in_game(function()
-        if not (C_CooldownViewer and C_CooldownViewer.GetLayoutData and C_CooldownViewer.SetLayoutData) then
-            T.skip("no cooldown viewer API")
+        if not MySlot:IsCooldownManagerSupported() then
+            T.skip("no cooldown manager support")
         end
         local original = C_CooldownViewer.GetLayoutData()
         if not original or original == "" then T.skip("no cooldown layout configured") end


### PR DESCRIPTION
## Summary

Hides export/import/clear options for features the running client can't use, instead of showing entries that fail or silently no-op on the wrong client.

| Feature | Gate | Why |
|---|---|---|
| Cooldown Manager | `C_AddOns.IsAddOnLoaded("Blizzard_CooldownViewer")` | The `C_CooldownViewer` namespace (incl. `GetLayoutData`/`SetLayoutData` and `IsCooldownViewerAvailable`) is present on Classic Era and even returns a real layout blob, so a namespace check leaks. The `Blizzard_CooldownViewer` addon (`## AllowLoadGameType: standard`, not LoadOnDemand) only loads on retail. |
| Click Cast Bindings | `C_ClickBindings` namespace | Genuinely absent on Classic (Blizzard's own `classic` SecureTemplates comment confirms). |
| Pet Action Bar | player class in `{HUNTER, WARLOCK, DEATHKNIGHT, MAGE}` | Pet APIs exist on every client; hiding is class-capability driven. Session-stable because the export menu is built once at load. |

## Changes

- **Myslot.lua**: add `IsCooldownManagerSupported`, `IsClickBindingSupported`, `IsPetActionBarSupported`; route export / recover / clear functional paths through them.
- **gui.lua**: filter unsupported entries out of the export/ignore menu; guard the `AllSettingMenuIgnored` checks so Export still disables correctly.
- **options.lua**: reflow the "Remove all…" buttons so hidden entries leave no layout gap.
- **ci/wow_stubs.lua** + **tests**: add `IsAddOnLoaded` stub and unit tests for the three predicates.
- **wow_roundtrip.lua**: in-game macro test now uses the authoritative macro index from the live list (CreateMacro's return isn't the macro index on Classic Era); cooldown test skip-guard uses `IsCooldownManagerSupported()`.

## Testing

- CI: 28 passed / 0 failed / 18 skipped
- luacheck clean
- In-game suite re-run on Classic Era 1.x recommended to confirm the macro + cooldown guards